### PR TITLE
Improved user experience on failed download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rr-image-downloader",
-  "version": "3.6.1",
+  "version": "3.7.1",
   "description": "RR Image Downloader - Download Rec Room user images.",
   "main": "dist/main/main/main.js",
   "homepage": "./",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -846,6 +846,21 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'open-path-in-explorer',
+  async (_event: IpcMainInvokeEvent, targetPath: string) => {
+    const resolved = path.resolve(targetPath);
+    if (!(await fs.pathExists(resolved))) {
+      return { success: false as const, error: 'Path does not exist' };
+    }
+    const errMsg = await shell.openPath(resolved);
+    if (errMsg) {
+      return { success: false as const, error: errMsg };
+    }
+    return { success: true as const };
+  }
+);
+
 // Auto-updater IPC handlers
 ipcMain.handle('check-for-updates', async (): Promise<void> => {
   if (!isDev) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -39,6 +39,8 @@ const electronAPI: ElectronAPI = {
   isFavorite: (photoId) => ipcRenderer.invoke('is-favorite', photoId),
 
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
+  openPathInExplorer: (targetPath: string) =>
+    ipcRenderer.invoke('open-path-in-explorer', targetPath),
 
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
   downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/src/main/services/__tests__/recnet-service.download.test.ts
+++ b/src/main/services/__tests__/recnet-service.download.test.ts
@@ -275,7 +275,7 @@ describe('RecNetService - Download Functionality', () => {
           value: new ArrayBuffer(1024),
           status: 200,
         } as GenericResponse<ArrayBuffer>)
-        .mockResolvedValueOnce({
+        .mockResolvedValue({
           success: false,
           value: null,
           status: 404,
@@ -286,8 +286,95 @@ describe('RecNetService - Download Functionality', () => {
 
       expect(result.downloadStats.newDownloads).toBe(1);
       expect(result.downloadStats.failedDownloads).toBe(1);
+      expect(result.downloadStats.retryAttempts).toBe(3);
       expect(result.downloadResults[1].status).toBe('failed');
+      expect(result.downloadResults[1].attempts).toBe(4);
       expect(mockedFs.writeFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry failed downloads and recover within the retry limit', async () => {
+      const photos: ImageDto[] = [createMockPhoto('photo-1', 'image1.jpg')];
+
+      const photosJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_photos.json`
+      );
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === photosJsonPath) return true;
+        return false;
+      });
+
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(photos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+
+      mockPhotosController.downloadPhoto
+        .mockResolvedValueOnce({
+          success: false,
+          value: null,
+          status: 503,
+          error: 'Temporary outage',
+        } as GenericResponse<ArrayBuffer>)
+        .mockResolvedValueOnce({
+          success: false,
+          value: null,
+          status: 503,
+          error: 'Temporary outage',
+        } as GenericResponse<ArrayBuffer>)
+        .mockResolvedValueOnce({
+          success: true,
+          value: new ArrayBuffer(1024),
+          status: 200,
+        } as GenericResponse<ArrayBuffer>);
+
+      const result = await service.downloadPhotos(testAccountId);
+
+      expect(result.downloadStats.newDownloads).toBe(1);
+      expect(result.downloadStats.failedDownloads).toBe(0);
+      expect(result.downloadStats.retryAttempts).toBe(2);
+      expect(result.downloadStats.recoveredAfterRetry).toBe(1);
+      expect(result.downloadResults[0].status).toBe('downloaded');
+      expect(result.downloadResults[0].attempts).toBe(3);
+      expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(3);
+    });
+
+    it('should stop retrying after three retries', async () => {
+      const photos: ImageDto[] = [createMockPhoto('photo-1', 'image1.jpg')];
+
+      const photosJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_photos.json`
+      );
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === photosJsonPath) return true;
+        return false;
+      });
+
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(photos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: false,
+        value: null,
+        status: 503,
+        error: 'Still failing',
+      } as GenericResponse<ArrayBuffer>);
+
+      const result = await service.downloadPhotos(testAccountId);
+
+      expect(result.downloadStats.newDownloads).toBe(0);
+      expect(result.downloadStats.failedDownloads).toBe(1);
+      expect(result.downloadStats.retryAttempts).toBe(3);
+      expect(result.downloadResults[0].status).toBe('failed');
+      expect(result.downloadResults[0].attempts).toBe(4);
+      expect(result.guidance).toEqual([
+        'Some user photos could not be downloaded after 3 retries, but the download completed.',
+        'You can retry the same download after it finishes to grab any missed images. Existing files are checked first, so the app will continue from what is already saved.',
+        'You do not need to delete the output folder to resume.',
+      ]);
+      expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(4);
     });
 
     /**
@@ -497,6 +584,37 @@ describe('RecNetService - Download Functionality', () => {
       expect(result.accountId).toBe(testAccountId);
       expect(result.downloadStats.newDownloads).toBe(2);
       expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry feed photo downloads before failing', async () => {
+      const feedPhotos: ImageDto[] = [createMockFeedPhoto('feed-1', 'feed1.jpg')];
+
+      const feedJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_feed.json`
+      );
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === feedJsonPath) return true;
+        return false;
+      });
+
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(feedPhotos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: false,
+        value: null,
+        status: 500,
+        error: 'CDN failure',
+      } as GenericResponse<ArrayBuffer>);
+
+      const result = await service.downloadFeedPhotos(testAccountId);
+
+      expect(result.downloadStats.failedDownloads).toBe(1);
+      expect(result.downloadStats.retryAttempts).toBe(3);
+      expect(result.downloadResults[0].attempts).toBe(4);
+      expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(4);
     });
 
     /**

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -28,12 +28,28 @@ interface CurrentOperation {
   cancelled: boolean;
 }
 
+interface PhotoDownloadAttempt {
+  response?: {
+    success: boolean;
+    value: ArrayBuffer | null;
+    error?: string | null;
+    message?: string | null;
+    status?: number;
+  };
+  error?: Error;
+  attempts: number;
+}
+
 const DEFAULT_SETTINGS: RecNetSettings = {
   outputRoot: 'output',
   cdnBase: 'https://img.rec.net/',
   globalMaxConcurrentDownloads: 1,
   interPageDelayMs: 500,
 };
+
+const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
+const PHOTO_DOWNLOAD_MAX_ATTEMPTS = PHOTO_DOWNLOAD_RETRY_COUNT + 1;
+const PHOTO_DOWNLOAD_RETRY_DELAY_MS = 750;
 
 export class RecNetService extends EventEmitter {
   private settingsPath: string;
@@ -55,13 +71,13 @@ export class RecNetService extends EventEmitter {
       'settings.json'
     );
     this.settings = { ...DEFAULT_SETTINGS };
-    this.progress = {
+    this.progress = this.createProgressState({
       isRunning: false,
       currentStep: '',
       progress: 0,
       total: 0,
       current: 0,
-    };
+    });
 
     this.httpClient = new RecNetHttpClient();
     this.photosController = new PhotosController(this.httpClient);
@@ -130,31 +146,57 @@ export class RecNetService extends EventEmitter {
     total: number,
     progress?: number
   ): void {
-    this.progress = {
+    this.progress = this.createProgressState({
+      ...this.progress,
       isRunning: true,
       currentStep: step,
       current,
       total,
       progress: progress || (total > 0 ? (current / total) * 100 : 0),
-    };
+    });
     this.emit('progress-update', this.progress);
   }
 
   private setOperationComplete(): void {
-    this.progress = {
+    this.progress = this.createProgressState({
+      ...this.progress,
       isRunning: false,
       currentStep: 'Complete',
       current: 0,
       total: 0,
       progress: 100,
-    };
+    });
+    this.emit('progress-update', this.progress);
+  }
+
+  private setOperationFailed(message: string): void {
+    this.progress = this.createProgressState({
+      ...this.progress,
+      isRunning: false,
+      currentStep: 'Failed',
+      current: 0,
+      total: 0,
+      progress: 100,
+      statusLevel: 'error',
+      issueCount: Math.max(this.progress.issueCount, 1),
+      failedItems: Math.max(this.progress.failedItems, 1),
+      lastIssue: message,
+    });
     this.emit('progress-update', this.progress);
   }
 
   cancelCurrentOperation(): boolean {
     if (this.currentOperation) {
       this.currentOperation.cancelled = true;
-      this.setOperationComplete();
+      this.progress = this.createProgressState({
+        ...this.progress,
+        isRunning: false,
+        currentStep: 'Cancelled',
+        current: 0,
+        total: 0,
+        progress: 100,
+      });
+      this.emit('progress-update', this.progress);
       return true;
     }
     return false;
@@ -174,6 +216,7 @@ export class RecNetService extends EventEmitter {
     } = options || {};
 
     try {
+      this.resetProgressIssueState();
       this.updateProgress('Downloading user photo data...', 0, 0, 0);
 
       const all: Photo[] = [];
@@ -450,7 +493,9 @@ export class RecNetService extends EventEmitter {
         iterationDetails,
       };
     } catch (error) {
-      this.setOperationComplete();
+      if ((error as Error).message !== 'Operation cancelled') {
+        this.setOperationFailed((error as Error).message);
+      }
       throw error;
     }
   }
@@ -470,6 +515,7 @@ export class RecNetService extends EventEmitter {
     } = options || {};
 
     try {
+      this.resetProgressIssueState();
       this.updateProgress('Downloading user feed data...', 0, 0, 0);
 
       const accountDir = path.join(this.settings.outputRoot, accountId);
@@ -725,7 +771,9 @@ export class RecNetService extends EventEmitter {
         iterationDetails,
       };
     } catch (error) {
-      this.setOperationComplete();
+      if ((error as Error).message !== 'Operation cancelled') {
+        this.setOperationFailed((error as Error).message);
+      }
       throw error;
     }
   }
@@ -735,6 +783,7 @@ export class RecNetService extends EventEmitter {
     this.currentOperation = { cancelled: false };
 
     try {
+      this.resetProgressIssueState();
       this.updateProgress('Downloading user photos...', 0, 0, 0);
       const accountDir = path.join(this.settings.outputRoot, accountId);
       const jsonPath = path.join(accountDir, `${accountId}_photos.json`);
@@ -806,6 +855,8 @@ export class RecNetService extends EventEmitter {
             newDownloads: 0,
             failedDownloads: 0,
             skipped: totalPhotos,
+            retryAttempts: 0,
+            recoveredAfterRetry: 0,
           },
           downloadResults: [],
           totalResults: 0,
@@ -823,6 +874,8 @@ export class RecNetService extends EventEmitter {
       let newDownloads = 0;
       let failedDownloads = 0;
       let skipped = 0;
+      let retryAttempts = 0;
+      let recoveredAfterRetry = 0;
       const downloadResults: DownloadResultItem[] = [];
       const rateLimitMs = 1000;
       let processedCount = 0;
@@ -895,12 +948,21 @@ export class RecNetService extends EventEmitter {
         }
 
         // Check if we've reached the download limit (only for new downloads)
+        let attemptsUsed = 1;
         try {
-          const response = await this.photosController.downloadPhoto(
-            imageName,
-            this.settings.cdnBase
-          );
-          if (response.success && response.value) {
+          const attempt = await this.downloadPhotoWithRetry(imageName);
+          attemptsUsed = attempt.attempts;
+          retryAttempts += Math.max(0, attempt.attempts - 1);
+          if (
+            attempt.attempts > 1 &&
+            attempt.response?.success &&
+            attempt.response.value
+          ) {
+            recoveredAfterRetry++;
+          }
+
+          const response = attempt.response;
+          if (response?.success && response.value) {
             const data = Buffer.from(response.value);
             await fs.writeFile(photoPath, data);
             newDownloads++;
@@ -911,8 +973,10 @@ export class RecNetService extends EventEmitter {
               size: data.length,
               path: photoPath,
               url: photoUrl,
+              attempts: attempt.attempts,
+              retries: Math.max(0, attempt.attempts - 1),
             });
-          } else {
+          } else if (response) {
             failedDownloads++;
             downloadResults.push({
               photoId,
@@ -920,15 +984,25 @@ export class RecNetService extends EventEmitter {
               statusCode: response.status,
               reason: (response.message || response.error) ?? undefined,
               url: photoUrl,
+              attempts: attempt.attempts,
+              retries: Math.max(0, attempt.attempts - 1),
             });
+          } else {
+            throw attempt.error ?? new Error('Download failed after retries');
           }
         } catch (error) {
+          if (error instanceof Error && error.message === 'Operation cancelled') {
+            throw error;
+          }
+
           failedDownloads++;
           downloadResults.push({
             photoId,
             status: 'error',
             error: (error as Error).message,
             url: photoUrl,
+            attempts: attemptsUsed,
+            retries: Math.max(0, attemptsUsed - 1),
           });
         }
 
@@ -953,6 +1027,8 @@ export class RecNetService extends EventEmitter {
         newDownloads,
         failedDownloads,
         skipped,
+        retryAttempts,
+        recoveredAfterRetry,
       };
 
       return {
@@ -962,9 +1038,12 @@ export class RecNetService extends EventEmitter {
         downloadStats,
         downloadResults,
         totalResults: downloadResults.length,
+        guidance: this.buildDownloadGuidance('user photos', downloadStats),
       };
     } catch (error) {
-      this.setOperationComplete();
+      if ((error as Error).message !== 'Operation cancelled') {
+        this.setOperationFailed((error as Error).message);
+      }
       throw error;
     }
   }
@@ -974,6 +1053,7 @@ export class RecNetService extends EventEmitter {
     this.currentOperation = { cancelled: false };
 
     try {
+      this.resetProgressIssueState();
       this.updateProgress('Downloading feed photos...', 0, 0, 0);
       const accountDir = path.join(this.settings.outputRoot, accountId);
       const feedJsonPath = path.join(accountDir, `${accountId}_feed.json`);
@@ -1044,6 +1124,8 @@ export class RecNetService extends EventEmitter {
             newDownloads: 0,
             failedDownloads: 0,
             skipped: totalPhotos,
+            retryAttempts: 0,
+            recoveredAfterRetry: 0,
           },
           downloadResults: [],
           totalResults: 0,
@@ -1061,6 +1143,8 @@ export class RecNetService extends EventEmitter {
       let newDownloads = 0;
       let failedDownloads = 0;
       let skipped = 0;
+      let retryAttempts = 0;
+      let recoveredAfterRetry = 0;
       const downloadResults: DownloadResultItem[] = [];
       const rateLimitMs = 1000;
       let processedCount = 0;
@@ -1131,12 +1215,21 @@ export class RecNetService extends EventEmitter {
           continue;
         }
 
+        let attemptsUsed = 1;
         try {
-          const response = await this.photosController.downloadPhoto(
-            imageName,
-            this.settings.cdnBase
-          );
-          if (response.success && response.value) {
+          const attempt = await this.downloadPhotoWithRetry(imageName);
+          attemptsUsed = attempt.attempts;
+          retryAttempts += Math.max(0, attempt.attempts - 1);
+          if (
+            attempt.attempts > 1 &&
+            attempt.response?.success &&
+            attempt.response.value
+          ) {
+            recoveredAfterRetry++;
+          }
+
+          const response = attempt.response;
+          if (response?.success && response.value) {
             const data = Buffer.from(response.value);
             await fs.writeFile(photoPath, data);
             newDownloads++;
@@ -1147,8 +1240,10 @@ export class RecNetService extends EventEmitter {
               size: data.length,
               path: photoPath,
               url: photoUrl,
+              attempts: attempt.attempts,
+              retries: Math.max(0, attempt.attempts - 1),
             });
-          } else {
+          } else if (response) {
             failedDownloads++;
             downloadResults.push({
               photoId,
@@ -1156,15 +1251,25 @@ export class RecNetService extends EventEmitter {
               statusCode: response.status,
               reason: (response.message || response.error) ?? undefined,
               url: photoUrl,
+              attempts: attempt.attempts,
+              retries: Math.max(0, attempt.attempts - 1),
             });
+          } else {
+            throw attempt.error ?? new Error('Download failed after retries');
           }
         } catch (error) {
+          if (error instanceof Error && error.message === 'Operation cancelled') {
+            throw error;
+          }
+
           failedDownloads++;
           downloadResults.push({
             photoId,
             status: 'error',
             error: (error as Error).message,
             url: photoUrl,
+            attempts: attemptsUsed,
+            retries: Math.max(0, attemptsUsed - 1),
           });
         }
 
@@ -1189,6 +1294,8 @@ export class RecNetService extends EventEmitter {
         newDownloads,
         failedDownloads,
         skipped,
+        retryAttempts,
+        recoveredAfterRetry,
       };
 
       return {
@@ -1198,9 +1305,12 @@ export class RecNetService extends EventEmitter {
         downloadStats,
         downloadResults,
         totalResults: downloadResults.length,
+        guidance: this.buildDownloadGuidance('feed photos', downloadStats),
       };
     } catch (error) {
-      this.setOperationComplete();
+      if ((error as Error).message !== 'Operation cancelled') {
+        this.setOperationFailed((error as Error).message);
+      }
       throw error;
     }
   }
@@ -1314,6 +1424,182 @@ export class RecNetService extends EventEmitter {
 
   private delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private createProgressState(overrides: Partial<Progress>): Progress {
+    return {
+      isRunning: false,
+      currentStep: 'Ready',
+      progress: 0,
+      total: 0,
+      current: 0,
+      statusLevel: 'info',
+      issueCount: 0,
+      retryAttempts: 0,
+      failedItems: 0,
+      recoveredAfterRetry: 0,
+      lastIssue: undefined,
+      ...overrides,
+    };
+  }
+
+  private resetProgressIssueState(): void {
+    this.progress = this.createProgressState({
+      ...this.progress,
+      statusLevel: 'info',
+      issueCount: 0,
+      retryAttempts: 0,
+      failedItems: 0,
+      recoveredAfterRetry: 0,
+      lastIssue: undefined,
+    });
+  }
+
+  private markProgressIssue(
+    level: 'warning' | 'error',
+    message: string,
+    options?: { retryIncrement?: number; failedItemIncrement?: number }
+  ): void {
+    const retryIncrement = options?.retryIncrement ?? 0;
+    const failedItemIncrement = options?.failedItemIncrement ?? 0;
+    const failedItems = this.progress.failedItems + failedItemIncrement;
+
+    this.progress = this.createProgressState({
+      ...this.progress,
+      statusLevel: level === 'error' || failedItems > 0 ? 'error' : 'warning',
+      issueCount: this.progress.issueCount + 1,
+      retryAttempts: this.progress.retryAttempts + retryIncrement,
+      failedItems,
+      lastIssue: message,
+    });
+    this.emit('progress-update', this.progress);
+  }
+
+  private markProgressRecovery(message: string): void {
+    this.progress = this.createProgressState({
+      ...this.progress,
+      statusLevel: this.progress.failedItems > 0 ? 'error' : 'warning',
+      recoveredAfterRetry: this.progress.recoveredAfterRetry + 1,
+      lastIssue: message,
+    });
+    this.emit('progress-update', this.progress);
+  }
+
+  private async downloadPhotoWithRetry(
+    imageName: string
+  ): Promise<PhotoDownloadAttempt> {
+    let attempts = 0;
+    let lastResponse: PhotoDownloadAttempt['response'];
+    let lastError: Error | undefined;
+
+    while (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
+      if (this.currentOperation?.cancelled) {
+        throw new Error('Operation cancelled');
+      }
+
+      attempts++;
+
+      try {
+        const response = await this.photosController.downloadPhoto(
+          imageName,
+          this.settings.cdnBase
+        );
+        if (response?.success && response.value) {
+          if (attempts > 1) {
+            this.markProgressRecovery(
+              `Recovered ${imageName} after ${attempts - 1} retr${
+                attempts - 1 === 1 ? 'y' : 'ies'
+              }. Download is continuing.`
+            );
+          }
+          return { response, attempts };
+        }
+
+        lastResponse = response ?? {
+          success: false,
+          value: null,
+          error: 'No response returned from photo download',
+        };
+        const failureReason =
+          lastResponse.message ||
+          lastResponse.error ||
+          (lastResponse.status ? `HTTP ${lastResponse.status}` : 'unknown_error');
+        const issueMessage =
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS
+            ? `Issue downloading ${imageName}: ${failureReason}. Retry ${attempts}/${PHOTO_DOWNLOAD_RETRY_COUNT} will start now.`
+            : `Download failed for ${imageName}: ${failureReason}.`;
+        this.markProgressIssue(
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 'warning' : 'error',
+          issueMessage,
+          {
+            retryIncrement: attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+            failedItemIncrement: attempts >= PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+          }
+        );
+        console.warn(
+          `Photo download attempt ${attempts}/${PHOTO_DOWNLOAD_MAX_ATTEMPTS} failed for ${imageName}: ${
+            lastResponse.message ||
+            lastResponse.error ||
+            lastResponse.status ||
+            'unknown_error'
+          }`
+        );
+      } catch (error) {
+        lastError = error as Error;
+        const failureReason = lastError.message || 'unknown_error';
+        const issueMessage =
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS
+            ? `Issue downloading ${imageName}: ${failureReason}. Retry ${attempts}/${PHOTO_DOWNLOAD_RETRY_COUNT} will start now.`
+            : `Download failed for ${imageName}: ${failureReason}.`;
+        this.markProgressIssue(
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 'warning' : 'error',
+          issueMessage,
+          {
+            retryIncrement: attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+            failedItemIncrement: attempts >= PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+          }
+        );
+        console.warn(
+          `Photo download attempt ${attempts}/${PHOTO_DOWNLOAD_MAX_ATTEMPTS} failed for ${imageName}: ${lastError.message}`
+        );
+      }
+
+      if (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
+        await this.delay(PHOTO_DOWNLOAD_RETRY_DELAY_MS);
+      }
+    }
+
+    if (lastResponse) {
+      return {
+        response: lastResponse,
+        error: lastError,
+        attempts,
+      };
+    }
+
+    if (lastError) {
+      return { error: lastError, attempts };
+    }
+
+    return {
+      error: new Error('Download failed after retries'),
+      attempts,
+    };
+  }
+
+  private buildDownloadGuidance(
+    label: string,
+    stats: DownloadStats
+  ): string[] | undefined {
+    if (stats.failedDownloads === 0) {
+      return undefined;
+    }
+
+    return [
+      `Some ${label} could not be downloaded after ${PHOTO_DOWNLOAD_RETRY_COUNT} retries, but the download completed.`,
+      'You can retry the same download after it finishes to grab any missed images. Existing files are checked first, so the app will continue from what is already saved.',
+      'You do not need to delete the output folder to resume.',
+    ];
   }
 
   private extractUniqueIds(photos: Photo[]): {
@@ -1731,13 +2017,13 @@ export class RecNetService extends EventEmitter {
 
       this.settings = { ...DEFAULT_SETTINGS };
       this.currentOperation = null;
-      this.progress = {
+      this.progress = this.createProgressState({
         isRunning: false,
         currentStep: 'Ready',
         progress: 0,
         total: 0,
         current: 0,
-      };
+      });
       this.ensureOutputDirectory();
       await this.saveSettings();
       this.emit('progress-update', this.progress);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,8 +11,22 @@ import {
   RecNetSettings,
   Progress,
   BulkDataRefreshOptions,
+  UserFacingIncident,
 } from '../shared/types';
 import { FavoritesProvider } from './contexts/FavoritesContext';
+import {
+  createUserIncident,
+  classifyError,
+  toOperationErrorData,
+} from './utils/errorPresentation';
+import { ErrorRecoveryBanner } from './components/ErrorRecoveryBanner';
+
+interface DownloadRequestState {
+  username: string;
+  token: string;
+  filePath: string;
+  refreshOptions: BulkDataRefreshOptions;
+}
 
 function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
@@ -28,17 +42,24 @@ function App() {
     progress: 0,
     total: 0,
     current: 0,
+    statusLevel: 'info',
+    issueCount: 0,
+    retryAttempts: 0,
+    failedItems: 0,
+    recoveredAfterRetry: 0,
   });
 
   const [currentAccountId, setCurrentAccountId] = useState<string>('');
   const [downloadPanelOpen, setDownloadPanelOpen] = useState(false);
   const [statsDialogOpen, setStatsDialogOpen] = useState(false);
+  const [debugMenuOpen, setDebugMenuOpen] = useState(false);
+  const [resultsScrollRequestId, setResultsScrollRequestId] = useState(0);
   const [isDownloading, setIsDownloading] = useState(false);
   const [headerMode, setHeaderMode] = useState<'full' | 'compact' | 'hidden'>(
     'full'
   );
-  const [hasScrolledDown, setHasScrolledDown] = useState(false);
   const [showProgressPanel, setShowProgressPanel] = useState(true);
+  const [hasScrolledDown, setHasScrolledDown] = useState(false);
   const [hasScrolledPhotos, setHasScrolledPhotos] = useState(false);
   const scrollPositionRef = useRef(0);
   const photoScrollRef = useRef<HTMLDivElement | null>(null);
@@ -57,6 +78,14 @@ function App() {
       timestamp: string;
     }>
   >([]);
+  const [downloadDraft, setDownloadDraft] = useState<DownloadRequestState | null>(
+    null
+  );
+  const [lastDownloadRequest, setLastDownloadRequest] =
+    useState<DownloadRequestState | null>(null);
+  const [activeIncident, setActiveIncident] = useState<UserFacingIncident | null>(
+    null
+  );
 
   useEffect(() => {
     loadSettings();
@@ -82,10 +111,10 @@ function App() {
         setSettings(loadedSettings);
       }
     } catch (error) {
-      addLog(
-        `Failed to load settings: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        'error'
-      );
+      const msg =
+        error instanceof Error ? error.message : 'Unknown error';
+      addLog(`Failed to load settings: ${msg}`, 'error');
+      setActiveIncident(createUserIncident('settings', msg));
     }
   };
 
@@ -93,6 +122,9 @@ function App() {
     if (window.electronAPI) {
       window.electronAPI.onProgress((event, progressData) => {
         setProgress(progressData);
+        if (progressData.statusLevel !== 'info' || progressData.issueCount > 0) {
+          setShowProgressPanel(true);
+        }
       });
     }
   };
@@ -103,10 +135,13 @@ function App() {
         await window.electronAPI.loadPhotos(accountId);
       }
     } catch (error) {
+      const msg =
+        error instanceof Error ? error.message : 'Unknown error';
       addLog(
-        `Failed to load photos for account ${accountId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Failed to load photos for account ${accountId}: ${msg}`,
         'error'
       );
+      setActiveIncident(createUserIncident('photos', msg));
     }
   };
 
@@ -119,7 +154,9 @@ function App() {
         addLog('Settings updated', 'success');
       }
     } catch (error) {
-      addLog(`Failed to update settings: ${error}`, 'error');
+      const msg = error instanceof Error ? error.message : String(error);
+      addLog(`Failed to update settings: ${msg}`, 'error');
+      setActiveIncident(createUserIncident('updateSettings', msg));
     }
   };
 
@@ -130,6 +167,33 @@ function App() {
     const timestamp = new Date().toLocaleTimeString();
     setLogs(prev => [...prev.slice(-99), { message, type, timestamp }]);
   };
+
+  const dismissIncident = useCallback(() => setActiveIncident(null), []);
+
+  const clearPhotosIncident = useCallback(() => {
+    setActiveIncident(prev => (prev?.source === 'photos' ? null : prev));
+  }, []);
+
+  const handleOpenPathInExplorer = useCallback(
+    async (folderPath: string) => {
+      if (!window.electronAPI?.openPathInExplorer) {
+        return;
+      }
+      const r = await window.electronAPI.openPathInExplorer(folderPath);
+      if (!r.success) {
+        const timestamp = new Date().toLocaleTimeString();
+        setLogs(prev => [
+          ...prev.slice(-99),
+          {
+            message: r.error ?? 'Could not open folder',
+            type: 'error' as const,
+            timestamp,
+          },
+        ]);
+      }
+    },
+    []
+  );
 
   const addResult = (
     operation: string,
@@ -146,7 +210,25 @@ function App() {
   const clearLogs = () => {
     setLogs([]);
     setResults([]);
+    setActiveIncident(null);
   };
+
+  const openOperationResults = useCallback(() => {
+    setDebugMenuOpen(true);
+    setResultsScrollRequestId(prev => prev + 1);
+  }, []);
+
+  const handleDownloadDraftChange = useCallback(
+    (draft: DownloadRequestState) => {
+      setDownloadDraft(draft);
+    },
+    []
+  );
+
+  const retryRequest = downloadDraft ?? lastDownloadRequest;
+  const canRetryDownload = Boolean(
+    retryRequest?.username.trim() && retryRequest?.filePath.trim()
+  );
 
   const isProgressIdle =
     !progress.isRunning &&
@@ -162,11 +244,26 @@ function App() {
     if (!username.trim() || !filePath.trim()) {
       return;
     }
+
+    setActiveIncident(null);
+
     const {
       forceAccountsRefresh = false,
       forceRoomsRefresh = false,
       forceEventsRefresh = false,
     } = refreshOptions;
+    const requestState: DownloadRequestState = {
+      username,
+      token,
+      filePath,
+      refreshOptions: {
+        forceAccountsRefresh,
+        forceRoomsRefresh,
+        forceEventsRefresh,
+      },
+    };
+
+    setLastDownloadRequest(requestState);
 
     setIsDownloading(true);
     addLog(`Starting download for username: ${username}`, 'info');
@@ -176,6 +273,11 @@ function App() {
       progress: 0,
       total: 0,
       current: 0,
+      statusLevel: 'info',
+      issueCount: 0,
+      retryAttempts: 0,
+      failedItems: 0,
+      recoveredAfterRetry: 0,
     });
 
     try {
@@ -274,15 +376,28 @@ function App() {
         const downloadStats = downloadResult.data?.downloadStats;
         if (downloadStats) {
           addLog(
-            `Download complete: ${downloadStats.newDownloads} new, ${downloadStats.alreadyDownloaded} existing, ${downloadStats.failedDownloads} failed`,
-            'success'
+            downloadStats.failedDownloads > 0
+              ? `Download complete with warnings: ${downloadStats.newDownloads} new, ${downloadStats.alreadyDownloaded} existing, ${downloadStats.failedDownloads} missed after retries`
+              : `Download complete: ${downloadStats.newDownloads} new, ${downloadStats.alreadyDownloaded} existing, ${downloadStats.failedDownloads} failed`,
+            downloadStats.failedDownloads > 0 ? 'warning' : 'success'
           );
+          if (downloadStats.retryAttempts > 0) {
+            addLog(
+              downloadStats.failedDownloads > 0
+                ? `Retried user photo downloads ${downloadStats.retryAttempts} time(s) across failed attempts. ${downloadStats.recoveredAfterRetry} photo(s) recovered automatically.`
+                : `Retried user photo downloads ${downloadStats.retryAttempts} time(s) and recovered ${downloadStats.recoveredAfterRetry} photo(s) automatically.`,
+              downloadStats.failedDownloads > 0 ? 'warning' : 'info'
+            );
+          }
           if (downloadResult.data?.photosDirectory) {
             addLog(
               `User photos saved to: ${downloadResult.data.photosDirectory}`,
               'info'
             );
           }
+          downloadResult.data?.guidance?.forEach(message =>
+            addLog(message, 'warning')
+          );
           addResult('Download', downloadResult.data, 'success');
         }
 
@@ -301,37 +416,111 @@ function App() {
         const downloadFeedStats = downloadFeedResult.data?.downloadStats;
         if (downloadFeedStats) {
           addLog(
-            `Feed download complete: ${downloadFeedStats.newDownloads} new, ${downloadFeedStats.alreadyDownloaded} existing, ${downloadFeedStats.failedDownloads} failed`,
-            'success'
+            downloadFeedStats.failedDownloads > 0
+              ? `Feed download complete with warnings: ${downloadFeedStats.newDownloads} new, ${downloadFeedStats.alreadyDownloaded} existing, ${downloadFeedStats.failedDownloads} missed after retries`
+              : `Feed download complete: ${downloadFeedStats.newDownloads} new, ${downloadFeedStats.alreadyDownloaded} existing, ${downloadFeedStats.failedDownloads} failed`,
+            downloadFeedStats.failedDownloads > 0 ? 'warning' : 'success'
           );
+          if (downloadFeedStats.retryAttempts > 0) {
+            addLog(
+              downloadFeedStats.failedDownloads > 0
+                ? `Retried feed photo downloads ${downloadFeedStats.retryAttempts} time(s) across failed attempts. ${downloadFeedStats.recoveredAfterRetry} photo(s) recovered automatically.`
+                : `Retried feed photo downloads ${downloadFeedStats.retryAttempts} time(s) and recovered ${downloadFeedStats.recoveredAfterRetry} photo(s) automatically.`,
+              downloadFeedStats.failedDownloads > 0 ? 'warning' : 'info'
+            );
+          }
           if (downloadFeedResult.data?.feedPhotosDirectory) {
             addLog(
               `Feed photos saved to: ${downloadFeedResult.data.feedPhotosDirectory}`,
               'info'
             );
           }
+          downloadFeedResult.data?.guidance?.forEach(message =>
+            addLog(message, 'warning')
+          );
           addResult('Feed Download', downloadFeedResult.data, 'success');
         }
 
         // Reload photos after download completes
         loadPhotosForAccount(accountId);
+        setActiveIncident(null);
       }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Download failed';
-      addLog(`Download failed: ${errorMessage}`, 'error');
-      addResult('Download', { error: errorMessage }, 'error');
+
+      if (errorMessage === 'Operation cancelled') {
+        addLog('Download cancelled by user.', 'warning');
+        setProgress(prev => ({
+          ...prev,
+          isRunning: false,
+          currentStep: 'Cancelled',
+          total: 0,
+          current: 0,
+          statusLevel: 'info',
+          issueCount: 0,
+          failedItems: 0,
+          lastIssue: undefined,
+        }));
+        setActiveIncident(
+          createUserIncident('download', errorMessage, { severity: 'warning' })
+        );
+      } else {
+        addLog(`Download failed: ${errorMessage}`, 'error');
+        classifyError(errorMessage, 'download').guidance.forEach(message =>
+          addLog(message, 'warning')
+        );
+        setShowProgressPanel(true);
+        setProgress(prev => ({
+          ...prev,
+          isRunning: false,
+          currentStep: 'Failed',
+          progress: 100,
+          total: 0,
+          current: 0,
+          statusLevel: 'error',
+          issueCount: Math.max(prev.issueCount, 1),
+          failedItems: Math.max(prev.failedItems, 1),
+          lastIssue: errorMessage,
+        }));
+        setActiveIncident(createUserIncident('download', errorMessage));
+        addResult(
+          'Download',
+          toOperationErrorData(errorMessage, 'download'),
+          'error'
+        );
+      }
     } finally {
       setIsDownloading(false);
-      setProgress({
+      setProgress(prev => ({
+        ...prev,
         isRunning: false,
-        currentStep: 'Complete',
-        progress: 100,
+        currentStep:
+          prev.currentStep === 'Cancelled'
+            ? 'Cancelled'
+            : prev.currentStep === 'Failed'
+              ? 'Failed'
+              : 'Complete',
+        progress:
+          prev.currentStep === 'Cancelled' ? prev.progress : 100,
         total: 0,
         current: 0,
-      });
+      }));
     }
   };
+
+  const handleRetryDownload = useCallback(async () => {
+    if (!retryRequest || isDownloading) {
+      return;
+    }
+
+    await handleDownload(
+      retryRequest.username,
+      retryRequest.token,
+      retryRequest.filePath,
+      retryRequest.refreshOptions
+    );
+  }, [handleDownload, isDownloading, retryRequest]);
 
   const handleViewerAccountChange = useCallback(
     (accountId?: string) => {
@@ -343,6 +532,18 @@ function App() {
     [isDownloading]
   );
 
+  const handleOpenActivityMenu = useCallback(() => {
+    setDebugMenuOpen(true);
+  }, []);
+
+  const handleRevealOutputFolder = useCallback(() => {
+    void handleOpenPathInExplorer(settings.outputRoot);
+  }, [handleOpenPathInExplorer, settings.outputRoot]);
+
+  const handlePhotosLoadError = useCallback((message: string) => {
+    setActiveIncident(createUserIncident('photos', message));
+  }, []);
+
   const handleCancelDownload = async () => {
     try {
       if (window.electronAPI) {
@@ -350,13 +551,14 @@ function App() {
         if (cancelled) {
           addLog('Download cancelled', 'warning');
           setIsDownloading(false);
-          setProgress({
+          setProgress(prev => ({
+            ...prev,
             isRunning: false,
             currentStep: 'Cancelled',
             progress: 0,
             total: 0,
             current: 0,
-          });
+          }));
         }
       }
     } catch (error) {
@@ -403,18 +605,38 @@ function App() {
     <FavoritesProvider>
       <div className="min-h-screen bg-background">
         {/* Custom Title Bar */}
-        <CustomTitleBar
-          onDownloadClick={() => setDownloadPanelOpen(true)}
-          onStatsClick={() => setStatsDialogOpen(true)}
-          settings={settings}
-          onUpdateSettings={updateSettings}
-          logs={logs}
-          results={results}
-          onClearLogs={clearLogs}
-          currentAccountId={currentAccountId}
-        />
+          <CustomTitleBar
+            onDownloadClick={() => setDownloadPanelOpen(true)}
+            onStatsClick={() => setStatsDialogOpen(true)}
+            settings={settings}
+            onUpdateSettings={updateSettings}
+            logs={logs}
+            results={results}
+            onClearLogs={clearLogs}
+            currentAccountId={currentAccountId}
+            debugMenuOpen={debugMenuOpen}
+            onDebugMenuOpenChange={setDebugMenuOpen}
+            resultsScrollRequestId={resultsScrollRequestId}
+            onRetryDownload={handleRetryDownload}
+            canRetryDownload={canRetryDownload}
+            isRetryingDownload={isDownloading}
+            onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+            onOpenOutputFolder={handleOpenPathInExplorer}
+            outputRoot={settings.outputRoot}
+          />
 
         <div className="container mx-auto px-4 py-4 max-w-7xl h-screen flex flex-col overflow-hidden pt-14">
+          <ErrorRecoveryBanner
+            incident={activeIncident}
+            outputRoot={settings.outputRoot}
+            onDismiss={dismissIncident}
+            onRetryDownload={handleRetryDownload}
+            canRetryDownload={canRetryDownload}
+            isRetrying={isDownloading}
+            onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+            onOpenOperationResults={openOperationResults}
+            onOpenPathInExplorer={handleOpenPathInExplorer}
+          />
           {/* Header space removed - using custom title bar instead */}
 
           {/* Download Panel Modal */}
@@ -423,6 +645,7 @@ function App() {
               open={downloadPanelOpen}
               onOpenChange={setDownloadPanelOpen}
               onDownload={handleDownload}
+              onDraftChange={handleDownloadDraftChange}
               onCancel={handleCancelDownload}
               isDownloading={isDownloading}
               settings={settings}
@@ -445,6 +668,11 @@ function App() {
               <ProgressDisplay
                 progress={progress}
                 onClose={() => setShowProgressPanel(false)}
+                onOpenOperationResults={openOperationResults}
+                onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+                onRetryDownload={handleRetryDownload}
+                canRetryDownload={canRetryDownload}
+                isRetrying={isDownloading}
               />
             </div>
           )}
@@ -453,7 +681,7 @@ function App() {
           <div className="flex-1 min-h-0 relative">
             {hasScrolledDown && headerMode === 'hidden' && (
               <div
-                className="absolute left-0 right-0 top-0 h-3 z-30"
+                className="absolute left-0 right-0 top-0 z-30 h-3"
                 onMouseEnter={() => setHeaderMode('compact')}
               />
             )}
@@ -466,6 +694,10 @@ function App() {
                 onScrollPositionChange={handlePhotoScroll}
                 scrollContainerRef={photoScrollRef}
                 headerMode={headerMode}
+                onOpenActivityMenu={handleOpenActivityMenu}
+                onRevealOutputFolder={handleRevealOutputFolder}
+                onPhotosLoadError={handlePhotosLoadError}
+                onPhotosLoadSuccess={clearPhotosIncident}
               />
             </ErrorBoundary>
           </div>

--- a/src/renderer/components/CustomTitleBar.tsx
+++ b/src/renderer/components/CustomTitleBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Minus, Square, X, Download, BarChart3, Settings } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { ThemeToggle } from './ThemeToggle';
@@ -33,6 +33,15 @@ interface CustomTitleBarProps {
   }>;
   onClearLogs: () => void;
   currentAccountId?: string;
+  debugMenuOpen: boolean;
+  onDebugMenuOpenChange: (open: boolean) => void;
+  resultsScrollRequestId: number;
+  onRetryDownload?: () => void | Promise<void>;
+  canRetryDownload?: boolean;
+  isRetryingDownload?: boolean;
+  onOpenDownloadPanel?: () => void;
+  onOpenOutputFolder?: (folderPath: string) => void | Promise<void>;
+  outputRoot: string;
 }
 
 export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
@@ -44,9 +53,18 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
   results,
   onClearLogs,
   currentAccountId,
+  debugMenuOpen,
+  onDebugMenuOpenChange,
+  resultsScrollRequestId,
+  onRetryDownload,
+  canRetryDownload,
+  isRetryingDownload,
+  onOpenDownloadPanel,
+  onOpenOutputFolder,
+  outputRoot,
 }) => {
   const [isMaximized, setIsMaximized] = useState(false);
-  const [debugMenuOpen, setDebugMenuOpen] = useState(false);
+  const resultsSectionRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const checkMaximized = async () => {
@@ -61,6 +79,21 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
     const interval = setInterval(checkMaximized, 500);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (!debugMenuOpen || resultsScrollRequestId === 0) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      resultsSectionRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }, 75);
+
+    return () => window.clearTimeout(timeout);
+  }, [debugMenuOpen, resultsScrollRequestId]);
 
   const handleMinimize = () => {
     if (window.electronAPI) {
@@ -136,7 +169,7 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
               variant="ghost"
               size="icon"
               className="h-8 w-8"
-              onClick={() => setDebugMenuOpen(true)}
+              onClick={() => onDebugMenuOpenChange(true)}
               aria-label="Settings"
             >
               <Settings className="h-4 w-4" />
@@ -167,7 +200,7 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
       </div>
 
       {/* Debug Menu Dialog */}
-      <Dialog open={debugMenuOpen} onOpenChange={setDebugMenuOpen}>
+      <Dialog open={debugMenuOpen} onOpenChange={onDebugMenuOpenChange}>
         <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
@@ -186,7 +219,17 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
               }}
             />
             <LogPanel logs={logs} onClearLogs={onClearLogs} />
-            <ResultsPanel results={results} />
+            <div ref={resultsSectionRef}>
+              <ResultsPanel
+                results={results}
+                onRetryDownload={onRetryDownload}
+                canRetryDownload={canRetryDownload}
+                isRetryingDownload={isRetryingDownload}
+                onOpenDownloadPanel={onOpenDownloadPanel}
+                onOpenOutputFolder={onOpenOutputFolder}
+                outputRoot={outputRoot}
+              />
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -32,6 +32,16 @@ interface DownloadPanelProps {
       forceEventsRefresh: boolean;
     }
   ) => Promise<void>;
+  onDraftChange?: (draft: {
+    username: string;
+    token: string;
+    filePath: string;
+    refreshOptions: {
+      forceAccountsRefresh: boolean;
+      forceRoomsRefresh: boolean;
+      forceEventsRefresh: boolean;
+    };
+  }) => void;
   onCancel?: () => void;
   isDownloading?: boolean;
   settings: RecNetSettings;
@@ -41,6 +51,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   open,
   onOpenChange,
   onDownload,
+  onDraftChange,
   onCancel,
   isDownloading = false,
   settings,
@@ -90,6 +101,27 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       setForceEventsRefresh(false);
     }
   }, [open]);
+
+  useEffect(() => {
+    onDraftChange?.({
+      username,
+      token,
+      filePath,
+      refreshOptions: {
+        forceAccountsRefresh,
+        forceRoomsRefresh,
+        forceEventsRefresh,
+      },
+    });
+  }, [
+    filePath,
+    forceAccountsRefresh,
+    forceEventsRefresh,
+    forceRoomsRefresh,
+    onDraftChange,
+    token,
+    username,
+  ]);
 
   // Re-validate token when accountId changes
   useEffect(() => {
@@ -521,6 +553,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               </Button>
             </div>
           </div>
+
+          {!isFormValid && (
+            <p className="text-sm text-muted-foreground">
+              Enter your username and save folder to start.
+            </p>
+          )}
 
           <div className="flex gap-2">
             <Button

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -55,17 +55,31 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         return fallback;
       }
       const name = this.props.sectionName ?? 'This section';
+      const err = this.state.error;
       return (
         <div
           className="flex flex-col items-center justify-center gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center"
           role="alert"
         >
-          <p className="text-sm text-muted-foreground">
-            {name} failed to load.
+          <p className="text-sm font-medium text-foreground">
+            {name} had a problem and was stopped so the rest of the app keeps working.
           </p>
-          <Button variant="outline" size="sm" onClick={this.handleRetry}>
-            Reload
-          </Button>
+          <p className="text-xs text-muted-foreground max-w-sm">
+            You can reload this section. If it happens again, try restarting the app.
+          </p>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Button variant="default" size="sm" onClick={this.handleRetry}>
+              Reload this section
+            </Button>
+          </div>
+          <details className="w-full max-w-md text-left text-xs text-muted-foreground">
+            <summary className="cursor-pointer select-none text-foreground/80">
+              Technical details
+            </summary>
+            <pre className="mt-2 whitespace-pre-wrap break-all rounded-md bg-muted/50 p-2 font-mono">
+              {err.message}
+            </pre>
+          </details>
         </div>
       );
     }

--- a/src/renderer/components/ErrorRecoveryBanner.tsx
+++ b/src/renderer/components/ErrorRecoveryBanner.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { AlertCircle, AlertTriangle, Copy, Check, X } from 'lucide-react';
+import { Button } from './ui/button';
+import type { UserFacingIncident } from '../../shared/types';
+
+export interface ErrorRecoveryBannerProps {
+  incident: UserFacingIncident | null;
+  outputRoot: string;
+  onDismiss: () => void;
+  onRetryDownload?: () => void | Promise<void>;
+  canRetryDownload?: boolean;
+  isRetrying?: boolean;
+  onOpenDownloadPanel?: () => void;
+  onOpenOperationResults?: () => void;
+  onOpenPathInExplorer?: (folderPath: string) => void | Promise<void>;
+}
+
+export const ErrorRecoveryBanner: React.FC<ErrorRecoveryBannerProps> = ({
+  incident,
+  outputRoot,
+  onDismiss,
+  onRetryDownload,
+  canRetryDownload = false,
+  isRetrying = false,
+  onOpenDownloadPanel,
+  onOpenOperationResults,
+  onOpenPathInExplorer,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  if (!incident) {
+    return null;
+  }
+
+  const isError = incident.severity === 'error';
+  const Icon = isError ? AlertCircle : AlertTriangle;
+  const borderTone = isError
+    ? 'border-destructive/40 bg-destructive/10'
+    : 'border-amber-500/40 bg-amber-500/10';
+
+  const showRetryDownload =
+    incident.source === 'download' &&
+    canRetryDownload &&
+    onRetryDownload &&
+    incident.category !== 'cancelled';
+
+  const showRetryAfterCancel =
+    incident.source === 'download' &&
+    incident.category === 'cancelled' &&
+    canRetryDownload &&
+    onRetryDownload;
+
+  const showOpenFolder =
+    Boolean(outputRoot?.trim()) &&
+    onOpenPathInExplorer &&
+    (incident.source === 'download' ||
+      incident.source === 'photos' ||
+      incident.source === 'settings' ||
+      incident.source === 'updateSettings' ||
+      incident.category === 'disk');
+
+  const handleCopy = async () => {
+    const text = [
+      incident.title,
+      incident.detail,
+      incident.technicalDetail && `Technical: ${incident.technicalDetail}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div
+      className={`border-b px-3 py-2.5 ${borderTone}`}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="mx-auto flex max-w-7xl flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 flex-1 gap-3">
+          <Icon
+            className={`mt-0.5 h-5 w-5 flex-shrink-0 ${isError ? 'text-destructive' : 'text-amber-600 dark:text-amber-400'}`}
+          />
+          <div className="min-w-0 space-y-1">
+            <p
+              className={`text-sm font-semibold ${isError ? 'text-destructive' : 'text-amber-900 dark:text-amber-100'}`}
+            >
+              {incident.title}
+            </p>
+            <p className="text-sm text-muted-foreground break-words">
+              {incident.detail}
+            </p>
+            {incident.guidance.length > 0 && (
+              <ul className="list-inside list-disc text-xs text-muted-foreground pt-1 space-y-0.5">
+                {incident.guidance.slice(0, 4).map((line, i) => (
+                  <li key={i}>{line}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-shrink-0 flex-col gap-2 sm:items-end">
+          <div className="flex flex-wrap gap-2">
+            {showRetryDownload && (
+              <Button
+                size="sm"
+                variant={isError ? 'default' : 'secondary'}
+                disabled={isRetrying}
+                onClick={() => void onRetryDownload()}
+              >
+                {isRetrying ? 'Retrying…' : 'Retry download'}
+              </Button>
+            )}
+            {showRetryAfterCancel && (
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={isRetrying}
+                onClick={() => void onRetryDownload()}
+              >
+                {isRetrying ? 'Starting…' : 'Run download again'}
+              </Button>
+            )}
+            {onOpenDownloadPanel && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onOpenDownloadPanel}
+              >
+                Open download
+              </Button>
+            )}
+            {showOpenFolder && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void onOpenPathInExplorer(outputRoot)}
+              >
+                Open output folder
+              </Button>
+            )}
+            {onOpenOperationResults && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onOpenOperationResults}
+              >
+                View details
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1"
+              onClick={handleCopy}
+              type="button"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1"
+              onClick={onDismiss}
+              aria-label="Dismiss"
+              type="button"
+            >
+              <X className="h-4 w-4" />
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/PhotoGrid.tsx
+++ b/src/renderer/components/PhotoGrid.tsx
@@ -296,8 +296,8 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
   const paddingBottom = Math.max(0, (totalRows - endRow) * ROW_HEIGHT);
 
   const renderVirtualizedGrid = () => (
-    <div className={`flex h-full flex-col space-y-4 ${className}`}>
-      <div ref={scrollRef} className="h-full overflow-auto">
+    <div className={`flex h-full min-h-0 flex-col space-y-4 ${className}`}>
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         <div
           style={{
             paddingTop,
@@ -410,8 +410,8 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
         : 0);
 
     return (
-      <div className={`flex h-full flex-col ${className}`}>
-        <div ref={scrollRef} className="h-full overflow-auto">
+      <div className={`flex h-full min-h-0 flex-col ${className}`}>
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
           <div style={{ paddingTop, paddingBottom }}>
             {visibleGroups.map(({ groupName, photos }) => (
               <div key={groupName} style={{ marginBottom: GROUP_SPACING }}>

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -34,7 +34,10 @@ interface PhotoViewerProps {
   onScrollPositionChange?: (scrollTop: number) => void;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
   headerMode?: 'full' | 'compact' | 'hidden';
-  onHeaderInteraction?: () => void;
+  onOpenActivityMenu?: () => void;
+  onRevealOutputFolder?: () => void;
+  onPhotosLoadError?: (message: string) => void;
+  onPhotosLoadSuccess?: () => void;
 }
 
 type PhotoSource = 'photos' | 'feed';
@@ -47,6 +50,10 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   onScrollPositionChange,
   scrollContainerRef,
   headerMode = 'full',
+  onOpenActivityMenu,
+  onRevealOutputFolder,
+  onPhotosLoadError,
+  onPhotosLoadSuccess,
 }) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -75,11 +82,21 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const internalScrollRef = useRef<HTMLDivElement | null>(null);
   const wasDownloadingRef = useRef(false);
+  const onPhotosLoadErrorRef = useRef(onPhotosLoadError);
+  const onPhotosLoadSuccessRef = useRef(onPhotosLoadSuccess);
   const activeScrollRef = scrollContainerRef ?? internalScrollRef;
-  const isHeaderVisible = headerMode !== 'hidden';
-  const showFullControls = headerMode === 'full';
   const { favorites } = useFavorites();
   const electronAPI = (window as unknown as { electronAPI?: any }).electronAPI;
+  const isHeaderVisible = headerMode !== 'hidden';
+  const showFullControls = headerMode === 'full';
+
+  useEffect(() => {
+    onPhotosLoadErrorRef.current = onPhotosLoadError;
+  }, [onPhotosLoadError]);
+
+  useEffect(() => {
+    onPhotosLoadSuccessRef.current = onPhotosLoadSuccess;
+  }, [onPhotosLoadSuccess]);
 
   // Use propAccountId if provided, otherwise use selectedAccountId
   const accountId = propAccountId || selectedAccountId;
@@ -116,7 +133,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     } finally {
       setLoadingAccounts(false);
     }
-  }, [selectedAccountId, propAccountId, onAccountChange]);
+  }, [electronAPI, selectedAccountId, propAccountId, onAccountChange]);
 
   const loadRoomData = useCallback(async () => {
     if (!accountId) {
@@ -144,7 +161,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       console.error('Failed to load room data:', error);
       setRoomMap(new Map());
     }
-  }, [accountId]);
+  }, [accountId, electronAPI]);
 
   const loadAccountData = useCallback(async () => {
     if (!accountId) {
@@ -171,7 +188,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       console.error('Failed to load account data:', error);
       setAccountMap(new Map());
     }
-  }, [accountId]);
+  }, [accountId, electronAPI]);
 
   const loadEventData = useCallback(async () => {
     if (!accountId) {
@@ -201,7 +218,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       console.error('Failed to load event data:', error);
       setEventMap(new Map());
     }
-  }, [accountId]);
+  }, [accountId, electronAPI]);
 
   const loadPhotos = useCallback(async () => {
     if (!filePath || !accountId) {
@@ -230,20 +247,21 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         } else {
           setFeedPhotos([]);
         }
+        onPhotosLoadSuccessRef.current?.();
       } else {
         setPhotos([]);
         setFeedPhotos([]);
       }
     } catch (error) {
-      setLoadError(
-        `Failed to load photos: ${error instanceof Error ? error.message : 'Unknown error'}. Check that your output folder is accessible.`
-      );
+      const msg = `Failed to load photos: ${error instanceof Error ? error.message : 'Unknown error'}. Check that your output folder is accessible.`;
+      setLoadError(msg);
+      onPhotosLoadErrorRef.current?.(msg);
       setPhotos([]);
       setFeedPhotos([]);
     } finally {
       setLoading(false);
     }
-  }, [filePath, accountId]);
+  }, [filePath, accountId, electronAPI]);
 
   // Load available accounts on mount and when filePath changes
   useEffect(() => {
@@ -355,16 +373,16 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   return (
     <div className="flex h-full flex-col gap-4 overflow-hidden">
       <div
-        className={`transition-[transform,opacity,max-height] duration-300 bg-background/95 backdrop-blur sticky top-0 z-10 ${
+        className={`sticky top-0 z-10 space-y-3 bg-background/95 px-3 py-3 backdrop-blur transition-[transform,opacity,max-height] duration-300 sm:px-4 lg:px-6 ${
           isHeaderVisible
-            ? 'translate-y-0 opacity-100 max-h-[600px]'
-            : '-translate-y-full opacity-0 pointer-events-none max-h-0'
-        } px-3 sm:px-4 lg:px-6 py-3 space-y-3`}
+            ? 'max-h-[600px] translate-y-0 opacity-100'
+            : 'pointer-events-none max-h-0 -translate-y-full opacity-0'
+        }`}
       >
         {showFullControls && (
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             {availableAccounts.length > 0 && (
-              <div className="flex items-center gap-3 min-w-0 flex-1">
+              <div className="flex min-w-0 flex-1 items-center gap-3">
                 <Select
                   value={accountId || ''}
                   onValueChange={handleAccountChange}
@@ -413,9 +431,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                 variant={showFavoritesOnly ? 'default' : 'outline'}
                 onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
                 className={
-                  showFavoritesOnly
-                    ? 'bg-red-500 hover:bg-red-600 text-white'
-                    : ''
+                  showFavoritesOnly ? 'bg-red-500 text-white hover:bg-red-600' : ''
                 }
               >
                 <Heart
@@ -428,9 +444,9 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         )}
 
         {(showFullControls || headerMode === 'compact') && (
-          <div className="flex flex-col sm:flex-row gap-4">
+          <div className="flex flex-col gap-4 sm:flex-row">
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
               <Input
                 placeholder="Search photos..."
                 value={searchQuery}
@@ -467,12 +483,8 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                 <SelectValue placeholder="Sort by" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="oldest-to-newest">
-                  Oldest to Newest
-                </SelectItem>
-                <SelectItem value="newest-to-oldest">
-                  Newest to Oldest
-                </SelectItem>
+                <SelectItem value="oldest-to-newest">Oldest to Newest</SelectItem>
+                <SelectItem value="newest-to-oldest">Newest to Oldest</SelectItem>
                 <SelectItem value="most-popular">Most Popular</SelectItem>
               </SelectContent>
             </Select>
@@ -494,8 +506,34 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
             <p>Loading photos...</p>
           </div>
         ) : loadError ? (
-          <div className="text-center py-12 text-red-600 dark:text-red-400">
-            <p>{loadError}</p>
+          <div className="mx-auto max-w-md rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center">
+            <p className="text-sm font-medium text-destructive">Could not load photos</p>
+            <p className="mt-2 text-sm text-muted-foreground break-words">
+              {loadError}
+            </p>
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-center">
+              <Button size="sm" onClick={() => void loadPhotos()}>
+                Try again
+              </Button>
+              {onRevealOutputFolder && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={onRevealOutputFolder}
+                >
+                  Open output folder
+                </Button>
+              )}
+              {onOpenActivityMenu && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={onOpenActivityMenu}
+                >
+                  Open activity and settings
+                </Button>
+              )}
+            </div>
           </div>
         ) : activePhotos.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">

--- a/src/renderer/components/ProgressDisplay.tsx
+++ b/src/renderer/components/ProgressDisplay.tsx
@@ -8,17 +8,33 @@ import {
   CardTitle,
 } from '../components/ui/card';
 import { Progress as ProgressType } from '../../shared/types';
-import { Loader2, CheckCircle2, X } from 'lucide-react';
+import {
+  Loader2,
+  CheckCircle2,
+  X,
+  AlertTriangle,
+  AlertCircle,
+} from 'lucide-react';
 import { Button } from '../components/ui/button';
 
 interface ProgressDisplayProps {
   progress: ProgressType;
   onClose?: () => void;
+  onOpenOperationResults?: () => void;
+  onOpenDownloadPanel?: () => void;
+  onRetryDownload?: () => void | Promise<void>;
+  canRetryDownload?: boolean;
+  isRetrying?: boolean;
 }
 
 export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
   progress,
   onClose,
+  onOpenOperationResults,
+  onOpenDownloadPanel,
+  onRetryDownload,
+  canRetryDownload = false,
+  isRetrying = false,
 }) => {
   const percent = Math.min(
     Math.max(Math.round(progress.progress ?? 0), 0),
@@ -26,6 +42,18 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
   );
   const hasTotals = progress.total > 0;
   const isComplete = !progress.isRunning && percent >= 100;
+  const isCancelled =
+    !progress.isRunning && progress.currentStep === 'Cancelled';
+  const hasIssues = progress.issueCount > 0;
+  const hasFailures =
+    !isCancelled &&
+    (progress.failedItems > 0 || progress.statusLevel === 'error');
+  const isRetryableCompletion =
+    !progress.isRunning &&
+    progress.currentStep === 'Complete' &&
+    progress.failedItems > 0;
+  const showErrorTone = hasFailures && !isRetryableCompletion;
+  const showWarningTone = hasIssues || isRetryableCompletion;
   const [indeterminateValue, setIndeterminateValue] = useState(15);
   const directionRef = useRef<1 | -1>(1);
 
@@ -66,20 +94,56 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
     : progress.isRunning
       ? indeterminateValue
       : percent;
+  const cardToneClass = isCancelled
+    ? 'border-muted-foreground/30 bg-muted/30'
+    : showErrorTone
+      ? 'border-red-500/70 bg-red-50/70 dark:bg-red-950/20'
+      : showWarningTone
+        ? 'border-yellow-500/70 bg-yellow-50/70 dark:bg-yellow-950/20'
+        : '';
+  const progressToneClass = showErrorTone
+    ? '[&>div]:bg-red-500'
+    : showWarningTone
+      ? '[&>div]:bg-yellow-500'
+      : '';
+  const statusToneClass = showErrorTone
+    ? 'text-red-700 dark:text-red-300'
+    : showWarningTone
+      ? 'text-yellow-700 dark:text-yellow-300'
+      : progress.isRunning
+        ? 'text-primary'
+        : 'text-muted-foreground';
+  const canOpenIssueDetails =
+    (showErrorTone || isRetryableCompletion) && !!onOpenOperationResults;
+  const issueMessage = isRetryableCompletion
+    ? 'The download finished, but some images were missed. Retry the download now to grab any missed images.'
+    : progress.lastIssue ||
+      'Some files are retrying. The download is still moving, but it is not clean.';
 
   if (isIdle) {
     return null;
   }
 
   return (
-    <Card>
+    <Card className={cardToneClass}>
       <CardHeader>
         <CardTitle className="flex items-center justify-between gap-2">
           <span className="flex items-center gap-2">
-            {progress.isRunning && <Loader2 className="h-5 w-5 animate-spin" />}
-            {isComplete && !progress.isRunning && (
-              <CheckCircle2 className="h-5 w-5 text-green-500" />
-            )}
+            {isCancelled ? (
+              <AlertTriangle className="h-5 w-5 text-muted-foreground" />
+            ) : showErrorTone ? (
+              <AlertCircle className="h-5 w-5 text-red-500" />
+            ) : showWarningTone ? (
+              <AlertTriangle className="h-5 w-5 text-yellow-500" />
+            ) : progress.isRunning ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : null}
+            {isComplete &&
+              !progress.isRunning &&
+              !showWarningTone &&
+              !isCancelled && (
+                <CheckCircle2 className="h-5 w-5 text-green-500" />
+              )}
             Download Progress
           </span>
           {onClose && (
@@ -94,22 +158,170 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
           )}
         </CardTitle>
         <CardDescription>
-          {progress.currentStep || (isComplete ? 'Complete' : 'Ready')}
+          {isCancelled
+            ? 'You cancelled this run. You can start a new download anytime.'
+            : isRetryableCompletion
+              ? 'Download complete. Retry the same download to grab any missed images.'
+            : progress.currentStep || (isComplete ? 'Complete' : 'Ready')}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex justify-between text-sm">
-          <span className="text-muted-foreground">Status</span>
-          <span
+        {showWarningTone && !isCancelled && (
+          <div
             className={
-              progress.isRunning ? 'text-primary' : 'text-muted-foreground'
+              showErrorTone
+                ? `rounded-md border border-red-300 bg-red-100/80 p-3 dark:border-red-900 dark:bg-red-950/40 ${
+                    canOpenIssueDetails ? 'cursor-pointer' : ''
+                  }`
+                : `rounded-md border border-yellow-300 bg-yellow-100/80 p-3 dark:border-yellow-900 dark:bg-yellow-950/40 ${
+                    canOpenIssueDetails ? 'cursor-pointer' : ''
+                  }`
+            }
+            onClick={canOpenIssueDetails ? onOpenOperationResults : undefined}
+            role={canOpenIssueDetails ? 'button' : undefined}
+            tabIndex={canOpenIssueDetails ? 0 : undefined}
+            onKeyDown={
+              canOpenIssueDetails
+                ? event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onOpenOperationResults?.();
+                    }
+                  }
+                : undefined
             }
           >
-            {progress.isRunning
-              ? 'In progress'
-              : isComplete
-                ? 'Complete'
-                : 'Idle'}
+            <div className="flex items-start gap-3">
+              {showErrorTone ? (
+                <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" />
+              ) : (
+                <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-400" />
+              )}
+              <div className="space-y-2">
+                <div>
+                  <p
+                    className={
+                      showErrorTone
+                        ? 'font-medium text-red-800 dark:text-red-200'
+                        : 'font-medium text-yellow-800 dark:text-yellow-200'
+                    }
+                  >
+                    {showErrorTone
+                      ? 'Download issues need attention'
+                      : isRetryableCompletion
+                        ? 'Download completed with missed images'
+                        : 'Download issues detected'}
+                  </p>
+                  <p
+                    className={
+                      showErrorTone
+                        ? 'text-sm text-red-700 dark:text-red-300'
+                        : 'text-sm text-yellow-700 dark:text-yellow-300'
+                    }
+                  >
+                    {issueMessage}
+                  </p>
+                  {canOpenIssueDetails && onOpenOperationResults && (
+                    <p
+                      className={
+                        showErrorTone
+                          ? 'pt-1 text-xs font-medium text-red-700 underline underline-offset-2 dark:text-red-300'
+                          : 'pt-1 text-xs font-medium text-yellow-800 underline underline-offset-2 dark:text-yellow-200'
+                      }
+                    >
+                      Click this area to jump to Operation Results.
+                    </p>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+                  <div className="rounded border border-current/15 px-2 py-1">
+                    Issue events: {progress.issueCount}
+                  </div>
+                  <div className="rounded border border-current/15 px-2 py-1">
+                    Retries used: {progress.retryAttempts}
+                  </div>
+                  <div className="rounded border border-current/15 px-2 py-1">
+                    Failed files: {progress.failedItems}
+                  </div>
+                  <div className="rounded border border-current/15 px-2 py-1">
+                    Recovered: {progress.recoveredAfterRetry}
+                  </div>
+                </div>
+
+                {(onOpenOperationResults ||
+                  onOpenDownloadPanel ||
+                  (onRetryDownload && canRetryDownload)) && (
+                  <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:flex-wrap">
+                    {onOpenOperationResults && (
+                      <Button
+                        variant={showErrorTone ? 'destructive' : 'outline'}
+                        size="sm"
+                        onClick={event => {
+                          event.stopPropagation();
+                          onOpenOperationResults();
+                        }}
+                        className="w-full sm:w-auto"
+                      >
+                        Open Operation Messages
+                      </Button>
+                    )}
+                    {onOpenDownloadPanel && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={event => {
+                          event.stopPropagation();
+                          onOpenDownloadPanel();
+                        }}
+                        className="w-full sm:w-auto"
+                      >
+                        Open download
+                      </Button>
+                    )}
+                    {onRetryDownload &&
+                      canRetryDownload &&
+                      !progress.isRunning && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isRetrying}
+                          onClick={event => {
+                            event.stopPropagation();
+                            void onRetryDownload();
+                          }}
+                          className="w-full sm:w-auto"
+                        >
+                          {isRetrying ? 'Retrying...' : 'Retry Download'}
+                        </Button>
+                      )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Status</span>
+          <span className={statusToneClass}>
+            {isCancelled
+              ? 'Cancelled'
+              : progress.isRunning
+                ? showErrorTone
+                  ? 'Issues detected'
+                  : showWarningTone
+                    ? 'Retrying with warnings'
+                    : 'In progress'
+                : isComplete
+                  ? isRetryableCompletion
+                    ? 'Complete with missed images'
+                    : showErrorTone
+                      ? 'Complete with failures'
+                      : showWarningTone
+                      ? 'Complete with warnings'
+                      : 'Complete'
+                  : 'Idle'}
           </span>
         </div>
 
@@ -121,17 +333,36 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
                 {progress.current} / {progress.total} ({percent}%)
               </span>
             </div>
-            <Progress value={barValue} className="h-2" />
+            <Progress value={barValue} className={`h-2 ${progressToneClass}`} />
           </>
         )}
 
         {!hasTotals && (
           <>
-            <Progress value={barValue} className="h-2" />
+            <Progress value={barValue} className={`h-2 ${progressToneClass}`} />
             <div className="text-sm text-muted-foreground">
               {progress.currentStep || 'Waiting to start'}
             </div>
           </>
+        )}
+
+        {isCancelled && !progress.isRunning && (
+          <div className="flex flex-wrap gap-2 border-t border-border/60 pt-3">
+            {onOpenDownloadPanel && (
+              <Button variant="outline" size="sm" onClick={onOpenDownloadPanel}>
+                Open download
+              </Button>
+            )}
+            {onRetryDownload && canRetryDownload && (
+              <Button
+                size="sm"
+                disabled={isRetrying}
+                onClick={() => void onRetryDownload()}
+              >
+                {isRetrying ? 'Starting…' : 'Run download again'}
+              </Button>
+            )}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/renderer/components/ResultsPanel.tsx
+++ b/src/renderer/components/ResultsPanel.tsx
@@ -13,6 +13,8 @@ import {
   CardHeader,
   CardTitle,
 } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import type { OperationResultErrorData } from '../../shared/types';
 
 interface Result {
   operation: string;
@@ -23,9 +25,23 @@ interface Result {
 
 interface ResultsPanelProps {
   results: Result[];
+  onRetryDownload?: () => void | Promise<void>;
+  canRetryDownload?: boolean;
+  isRetryingDownload?: boolean;
+  onOpenDownloadPanel?: () => void;
+  onOpenOutputFolder?: (folderPath: string) => void | Promise<void>;
+  outputRoot?: string;
 }
 
-export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results }) => {
+export const ResultsPanel: React.FC<ResultsPanelProps> = ({
+  results,
+  onRetryDownload,
+  canRetryDownload = false,
+  isRetryingDownload = false,
+  onOpenDownloadPanel,
+  onOpenOutputFolder,
+  outputRoot = '',
+}) => {
   const getResultIcon = (type: 'success' | 'error') => {
     return type === 'success' ? (
       <CheckCircle className="w-5 h-5 text-green-600 dark:text-green-400" />
@@ -42,16 +58,78 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results }) => {
 
   const renderResultContent = (result: Result) => {
     if (result.type === 'error') {
-      const errorData = result.data as { error?: string };
+      const errorData = result.data as OperationResultErrorData;
+      const headline =
+        errorData.title ||
+        (result.operation === 'Download'
+          ? 'Download failed'
+          : 'Something went wrong');
+      const isDownloadOp = result.operation === 'Download';
+      const showRetry =
+        isDownloadOp &&
+        canRetryDownload &&
+        onRetryDownload &&
+        errorData.category !== 'cancelled';
+
       return (
-        <div className="flex items-start gap-3">
-          <XCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-          <div>
-            <p className="text-red-600 dark:text-red-400 font-medium">Error:</p>
-            <p className="text-red-600 dark:text-red-400 text-sm">
-              {errorData.error || 'Unknown error'}
-            </p>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <XCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
+            <div className="space-y-2 min-w-0 flex-1">
+              <div>
+                <p className="text-red-600 dark:text-red-400 font-medium">
+                  {headline}
+                </p>
+                <p className="text-red-600/90 dark:text-red-400/90 text-sm break-words">
+                  {errorData.error || 'Unknown error'}
+                </p>
+              </div>
+
+              {errorData.guidance && errorData.guidance.length > 0 && (
+                <div className="space-y-1">
+                  {errorData.guidance.map((message, index) => (
+                    <div key={index} className="flex items-start gap-2">
+                      <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+                      <p className="text-yellow-700 dark:text-yellow-300 text-sm">
+                        {message}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
+
+          {(showRetry ||
+            onOpenDownloadPanel ||
+            (onOpenOutputFolder && outputRoot.trim())) && (
+            <div className="flex flex-wrap gap-2 pl-8">
+              {showRetry && (
+                <Button
+                  size="sm"
+                  variant="default"
+                  disabled={isRetryingDownload}
+                  onClick={() => void onRetryDownload()}
+                >
+                  {isRetryingDownload ? 'Retrying…' : 'Retry download'}
+                </Button>
+              )}
+              {onOpenDownloadPanel && (
+                <Button size="sm" variant="outline" onClick={onOpenDownloadPanel}>
+                  Open download
+                </Button>
+              )}
+              {onOpenOutputFolder && outputRoot.trim() ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void onOpenOutputFolder(outputRoot)}
+                >
+                  Open output folder
+                </Button>
+              ) : null}
+            </div>
+          )}
         </div>
       );
     }
@@ -63,10 +141,13 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results }) => {
         newDownloads: number;
         alreadyDownloaded: number;
         failedDownloads: number;
+        retryAttempts: number;
+        recoveredAfterRetry: number;
       };
       saved?: string;
       photosDirectory?: string;
       feedPhotosDirectory?: string;
+      guidance?: string[];
     };
 
     return (
@@ -105,6 +186,18 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results }) => {
               </span>
             </div>
 
+            {data.downloadStats.retryAttempts > 0 && (
+              <div className="flex items-center gap-2">
+                <Info className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+                <span className="text-blue-600 dark:text-blue-400">
+                  Retry attempts: {data.downloadStats.retryAttempts}
+                  {data.downloadStats.recoveredAfterRetry > 0
+                    ? ` (${data.downloadStats.recoveredAfterRetry} recovered)`
+                    : ''}
+                </span>
+              </div>
+            )}
+
             {data.downloadStats.failedDownloads > 0 && (
               <div className="flex items-center gap-2">
                 <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
@@ -140,6 +233,19 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ results }) => {
             <span className="text-blue-600 dark:text-blue-400 text-sm">
               Feed: {data.feedPhotosDirectory}
             </span>
+          </div>
+        )}
+
+        {data.guidance && data.guidance.length > 0 && (
+          <div className="space-y-1 pt-1">
+            {data.guidance.map((message, index) => (
+              <div key={index} className="flex items-start gap-2">
+                <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+                <p className="text-yellow-700 dark:text-yellow-300 text-sm">
+                  {message}
+                </p>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/src/renderer/components/StatsDialog.tsx
+++ b/src/renderer/components/StatsDialog.tsx
@@ -389,6 +389,8 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
   const [accountMap, setAccountMap] = useState<Map<string, string>>(new Map());
   const [expandedRooms, setExpandedRooms] = useState(false);
   const [expandedUsers, setExpandedUsers] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [statsReloadToken, setStatsReloadToken] = useState(0);
 
   const { getPhotoRoom, getPhotoUsers } = usePhotoMetadata(roomMap, accountMap);
 
@@ -453,11 +455,13 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
     if (!open || !accountId || !filePath) {
       setPhotos([]);
       setFeedPhotos([]);
+      setLoadError(null);
       return;
     }
 
     const loadData = async () => {
       setLoading(true);
+      setLoadError(null);
       try {
         if (window.electronAPI) {
           const [photosResult, feedPhotosResult] = await Promise.all([
@@ -465,22 +469,31 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
             window.electronAPI.loadFeedPhotos(accountId),
           ]);
 
-          if (photosResult.success && photosResult.data) {
-            setPhotos(photosResult.data);
-          }
-          if (feedPhotosResult.success && feedPhotosResult.data) {
-            setFeedPhotos(feedPhotosResult.data);
+          const photosOk = photosResult.success && photosResult.data;
+          const feedOk = feedPhotosResult.success && feedPhotosResult.data;
+
+          setPhotos(photosOk ? photosResult.data! : []);
+          setFeedPhotos(feedOk ? feedPhotosResult.data! : []);
+
+          if (!photosOk && !feedOk) {
+            const hint =
+              (!photosResult.success && photosResult.error) ||
+              (!feedPhotosResult.success && feedPhotosResult.error) ||
+              'Could not load photos for this account.';
+            setLoadError(hint);
           }
         }
       } catch (error) {
-        // Failed to load photos
+        setLoadError(
+          error instanceof Error ? error.message : 'Could not load photos.'
+        );
       } finally {
         setLoading(false);
       }
     };
 
     loadData();
-  }, [open, accountId, filePath]);
+  }, [open, accountId, filePath, statsReloadToken]);
 
   // Calculate statistics
   const stats = useMemo((): PhotoStats => {
@@ -716,6 +729,20 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
         {loading ? (
           <div className="py-8 text-center text-muted-foreground">
             Loading statistics...
+          </div>
+        ) : loadError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center space-y-3">
+            <p className="text-sm font-medium text-destructive">
+              Could not load statistics
+            </p>
+            <p className="text-sm text-muted-foreground break-words">{loadError}</p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setStatsReloadToken(t => t + 1)}
+            >
+              Try again
+            </Button>
           </div>
         ) : photos.length === 0 && feedPhotos.length === 0 ? (
           <div className="py-8 text-center text-muted-foreground">

--- a/src/renderer/components/UpdateIndicator.tsx
+++ b/src/renderer/components/UpdateIndicator.tsx
@@ -155,6 +155,11 @@ export const UpdateIndicator: React.FC = () => {
           {error ? (
             <div className="space-y-2">
               <p className="text-xs text-muted-foreground">{error}</p>
+              {/network|offline|ENOTFOUND|timeout|internet/i.test(error) && (
+                <p className="text-xs text-muted-foreground">
+                  Check your internet connection, then try again.
+                </p>
+              )}
               <Button
                 variant="outline"
                 size="sm"

--- a/src/renderer/utils/errorPresentation.ts
+++ b/src/renderer/utils/errorPresentation.ts
@@ -1,0 +1,194 @@
+import type {
+  ErrorContext,
+  OperationResultErrorData,
+  UserErrorCategory,
+  UserFacingIncident,
+} from '../../shared/types';
+
+const DOWNLOAD_RESUME = [
+  'Anything already saved on disk is still available.',
+  'Run the same download again to continue. Existing files are skipped automatically.',
+  'You do not need to delete the output folder to resume.',
+] as const;
+
+function truncateDetail(s: string, max = 220): string {
+  const t = s.trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1)}…`;
+}
+
+function detectCategory(message: string): UserErrorCategory {
+  if (/^operation cancelled$/i.test(message)) return 'cancelled';
+  if (/account not found/i.test(message)) return 'account';
+  if (/token|401|403|unauthorized|forbidden/i.test(message)) return 'auth';
+  if (
+    /ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|fetch failed|getaddrinfo|socket hang|network|timed out|offline/i.test(
+      message
+    )
+  ) {
+    return 'network';
+  }
+  if (
+    /ENOSPC|EACCES|EPERM|ENOENT|no space|permission denied|disk full|not writable|path.*not found/i.test(
+      message
+    )
+  ) {
+    return 'disk';
+  }
+  return 'unknown';
+}
+
+function pickTitle(context: ErrorContext, category: UserErrorCategory): string {
+  if (category === 'cancelled') return 'Download cancelled';
+
+  if (context === 'download') {
+    if (category === 'account') return 'We could not find that account';
+    if (category === 'auth') return 'Access was denied';
+    if (category === 'network') return 'Could not reach RecNet';
+    if (category === 'disk') return 'Could not use your save folder';
+    return 'Download could not finish';
+  }
+  if (context === 'settings') return 'Could not load settings';
+  if (context === 'photos') return 'Could not load photos';
+  if (context === 'updateSettings') return 'Could not save settings';
+  return 'Something went wrong';
+}
+
+function buildGuidance(
+  context: ErrorContext,
+  category: UserErrorCategory,
+  message: string
+): string[] {
+  const g: string[] = [];
+
+  if (context === 'download') {
+    if (category !== 'cancelled') {
+      g.push(...DOWNLOAD_RESUME);
+    }
+    if (category === 'auth' || /token|401|403/i.test(message)) {
+      g.push(
+        'Paste a fresh access token in Download if you need private photos, then try again.'
+      );
+    }
+    if (category === 'account') {
+      g.push(
+        'Check the spelling of the RecNet username or use the exact @name from the profile.'
+      );
+    }
+    if (category === 'network') {
+      g.push(
+        'Check your internet connection, then use Retry or run Download again.'
+      );
+    }
+    if (category === 'disk') {
+      g.push(
+        'Pick a folder you can download to, confirm there is free disk space, and try again.'
+      );
+    }
+    if (category === 'unknown') {
+      g.push('Use View details for logs, or try Retry after a moment.');
+    }
+    if (category === 'cancelled') {
+      g.push(
+        'Run Download again anytime; files already saved are kept and skipped automatically.'
+      );
+    }
+    return g;
+  }
+
+  if (category === 'network') {
+    g.push('Check your internet connection and try again.');
+  }
+  if (
+    category === 'disk' ||
+    context === 'settings' ||
+    context === 'updateSettings'
+  ) {
+    g.push(
+      'Confirm the output folder exists, is on a reachable drive, and the app can read and write there.'
+    );
+  }
+  if (context === 'photos') {
+    g.push(
+      'Open your output folder to verify files are present for this account.'
+    );
+    g.push('Use Open activity (gear) to review paths in settings if needed.');
+  }
+  if (context === 'settings') {
+    g.push('Restart the app if this message appears every launch.');
+  }
+  if (context === 'updateSettings') {
+    g.push(
+      'Check disk space and folder permissions, then change settings again.'
+    );
+  }
+  if (g.length === 0) {
+    g.push(
+      'Try again. If it keeps failing, use View details for more information.'
+    );
+  }
+  return g;
+}
+
+export interface ClassifiedError {
+  category: UserErrorCategory;
+  title: string;
+  detail: string;
+  guidance: string[];
+}
+
+export function classifyError(
+  rawMessage: string,
+  context: ErrorContext
+): ClassifiedError {
+  const message = (rawMessage || 'Something went wrong').trim();
+
+  if (context === 'download' && /^operation cancelled$/i.test(message)) {
+    return {
+      category: 'cancelled',
+      title: pickTitle(context, 'cancelled'),
+      detail: 'You stopped the download.',
+      guidance: buildGuidance(context, 'cancelled', message),
+    };
+  }
+
+  const category = detectCategory(message);
+  const title = pickTitle(context, category);
+  const detail = truncateDetail(message);
+  const guidance = buildGuidance(context, category, message);
+
+  return { category, title, detail, guidance };
+}
+
+export function toOperationErrorData(
+  rawMessage: string,
+  context: ErrorContext
+): OperationResultErrorData {
+  const c = classifyError(rawMessage, context);
+  return {
+    error: rawMessage,
+    title: c.title,
+    category: c.category,
+    guidance: c.guidance,
+  };
+}
+
+export function createUserIncident(
+  source: ErrorContext,
+  rawMessage: string,
+  options?: { severity?: 'error' | 'warning'; technicalDetail?: string }
+): UserFacingIncident {
+  const c = classifyError(rawMessage, source);
+  const severity =
+    options?.severity ?? (c.category === 'cancelled' ? 'warning' : 'error');
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    source,
+    severity,
+    category: c.category,
+    title: c.title,
+    detail: c.detail,
+    guidance: c.guidance,
+    technicalDetail: options?.technicalDetail ?? rawMessage,
+  };
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -58,6 +58,9 @@ export interface ElectronAPI {
   isFavorite: (photoId: string) => Promise<ApiResponse<boolean>>;
 
   openExternal: (url: string) => Promise<void>;
+  openPathInExplorer: (
+    targetPath: string
+  ) => Promise<{ success: boolean; error?: string }>;
 
   checkForUpdates: () => Promise<void>;
   downloadUpdate: () => Promise<void>;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -25,6 +25,12 @@ export interface Progress {
   progress: number;
   total: number;
   current: number;
+  statusLevel: 'info' | 'warning' | 'error';
+  issueCount: number;
+  retryAttempts: number;
+  failedItems: number;
+  recoveredAfterRetry: number;
+  lastIssue?: string;
 }
 
 export type Photo = Omit<ImageDto, 'PlayerEventId'> & {
@@ -82,6 +88,8 @@ export interface DownloadStats {
   newDownloads: number;
   failedDownloads: number;
   skipped: number;
+  retryAttempts: number;
+  recoveredAfterRetry: number;
 }
 
 export interface DownloadResultItem {
@@ -97,6 +105,8 @@ export interface DownloadResultItem {
   error?: string;
   photo?: string;
   imageName?: string;
+  attempts?: number;
+  retries?: number;
 }
 
 export interface DownloadResult {
@@ -107,12 +117,49 @@ export interface DownloadResult {
   downloadStats: DownloadStats;
   downloadResults: DownloadResultItem[];
   totalResults: number;
+  guidance?: string[];
 }
 
 export interface ApiResponse<T> {
   success: boolean;
   data?: T;
   error?: string;
+}
+
+/** Where a user-facing error originated (drives copy and recovery actions). */
+export type ErrorContext =
+  | 'download'
+  | 'settings'
+  | 'photos'
+  | 'updateSettings';
+
+export type UserErrorCategory =
+  | 'auth'
+  | 'network'
+  | 'account'
+  | 'disk'
+  | 'cancelled'
+  | 'settings'
+  | 'unknown';
+
+/** Stored on failed operation rows in Operation Results. */
+export interface OperationResultErrorData {
+  error: string;
+  guidance?: string[];
+  category?: UserErrorCategory;
+  title?: string;
+}
+
+/** Inline banner / recovery state in the shell. */
+export interface UserFacingIncident {
+  id: string;
+  source: ErrorContext;
+  severity: 'error' | 'warning';
+  category: UserErrorCategory;
+  title: string;
+  detail: string;
+  guidance: string[];
+  technicalDetail?: string;
 }
 
 export interface AvailableAccount {


### PR DESCRIPTION
- Added ugly warning and error messages with context for users with clear paths to continue the download
- If a file fails to download it will attempt to download it 4 times before moving on.  At the end of a download the UI will show how many files failed to download and lets the user know that rerunning the download will allow it to try and download the missed files again.
- download progress UI will clearly indicate when an error was hit