### PR TITLE
Cleaned up App Settings

### DIFF
--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -14,6 +14,10 @@ import {
   AccountInfo,
   BulkDataRefreshOptions,
 } from '../../shared/types';
+import {
+  buildCdnImageUrl,
+  DEFAULT_CDN_BASE,
+} from '../../shared/cdnUrl';
 import { EventDto } from '../models/EventDto';
 import { ImageDto } from '../models/ImageDto';
 import { PlayerResult } from '../models/PlayerDto';
@@ -42,14 +46,45 @@ interface PhotoDownloadAttempt {
 
 const DEFAULT_SETTINGS: RecNetSettings = {
   outputRoot: 'output',
-  cdnBase: 'https://img.rec.net/',
-  globalMaxConcurrentDownloads: 1,
+  cdnBase: DEFAULT_CDN_BASE,
   interPageDelayMs: 500,
 };
 
 const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
 const PHOTO_DOWNLOAD_MAX_ATTEMPTS = PHOTO_DOWNLOAD_RETRY_COUNT + 1;
 const PHOTO_DOWNLOAD_RETRY_DELAY_MS = 750;
+
+function normalizeRecNetSettings(input: unknown): RecNetSettings {
+  const raw =
+    input && typeof input === 'object'
+      ? (input as Record<string, unknown>)
+      : {};
+
+  const interRaw = raw.interPageDelayMs;
+  const interPageDelayMs =
+    typeof interRaw === 'number' && Number.isFinite(interRaw)
+      ? interRaw
+      : DEFAULT_SETTINGS.interPageDelayMs;
+
+  const maxRaw = raw.maxPhotosToDownload;
+  const maxPhotosToDownload =
+    typeof maxRaw === 'number' && Number.isFinite(maxRaw) && maxRaw > 0
+      ? Math.floor(maxRaw)
+      : undefined;
+
+  return {
+    outputRoot:
+      typeof raw.outputRoot === 'string' && raw.outputRoot.length > 0
+        ? raw.outputRoot
+        : DEFAULT_SETTINGS.outputRoot,
+    cdnBase:
+      typeof raw.cdnBase === 'string' && raw.cdnBase.length > 0
+        ? raw.cdnBase
+        : DEFAULT_SETTINGS.cdnBase,
+    interPageDelayMs,
+    maxPhotosToDownload,
+  };
+}
 
 export class RecNetService extends EventEmitter {
   private settingsPath: string;
@@ -97,7 +132,10 @@ export class RecNetService extends EventEmitter {
     try {
       if (await fs.pathExists(this.settingsPath)) {
         const savedSettings = await fs.readJson(this.settingsPath);
-        this.settings = { ...this.settings, ...savedSettings };
+        this.settings = normalizeRecNetSettings({
+          ...DEFAULT_SETTINGS,
+          ...savedSettings,
+        });
         console.log('Settings loaded from disk:', this.settings);
       }
     } catch (error) {
@@ -130,7 +168,7 @@ export class RecNetService extends EventEmitter {
     newSettings: Partial<RecNetSettings>
   ): Promise<RecNetSettings> {
     await this.ensureSettingsLoaded();
-    this.settings = { ...this.settings, ...newSettings };
+    this.settings = normalizeRecNetSettings({ ...this.settings, ...newSettings });
     this.ensureOutputDirectory();
     await this.saveSettings();
     return this.settings;
@@ -888,7 +926,7 @@ export class RecNetService extends EventEmitter {
 
         const photoId = this.normalizeId(photo.Id);
         const imageName = photo.ImageName;
-        const photoUrl = `${this.settings.cdnBase}${imageName}`;
+        const photoUrl = buildCdnImageUrl(this.settings.cdnBase, imageName);
 
         if (!photoId || !imageName) {
           downloadResults.push({
@@ -1156,7 +1194,7 @@ export class RecNetService extends EventEmitter {
 
         const photoId = this.normalizeId(photo.Id);
         const imageName = photo.ImageName;
-        const photoUrl = `${this.settings.cdnBase}${imageName}`;
+        const photoUrl = buildCdnImageUrl(this.settings.cdnBase, imageName);
 
         if (!photoId || !imageName) {
           downloadResults.push({

--- a/src/main/services/recnet/photos-controller.ts
+++ b/src/main/services/recnet/photos-controller.ts
@@ -1,3 +1,4 @@
+import { buildCdnImageUrl } from '../../../shared/cdnUrl';
 import { ImageDto } from '../../models/ImageDto';
 import { GenericResponse } from '../../models/GenericResponse';
 import { RecNetHttpClient } from './http-client';
@@ -36,10 +37,10 @@ export class PhotosController {
     cdnBase: string,
     token?: string
   ): Promise<GenericResponse<ArrayBuffer>> {
-    const normalizedBase = cdnBase.endsWith('/') ? cdnBase : `${cdnBase}/`;
+    const url = buildCdnImageUrl(cdnBase, imageName);
     return this.http.request<ArrayBuffer>(
       {
-        url: `${normalizedBase}${imageName}`,
+        url,
         method: 'GET',
         responseType: 'arraybuffer',
       },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import { ProgressDisplay } from './components/ProgressDisplay';
 import { StatsDialog } from './components/StatsDialog';
 import { CustomTitleBar } from './components/CustomTitleBar';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { DEFAULT_CDN_BASE } from '../shared/cdnUrl';
 import {
   RecNetSettings,
   Progress,
@@ -31,8 +32,7 @@ interface DownloadRequestState {
 function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
     outputRoot: 'output',
-    cdnBase: 'https://img.rec.net/',
-    globalMaxConcurrentDownloads: 1,
+    cdnBase: DEFAULT_CDN_BASE,
     interPageDelayMs: 500,
   });
 
@@ -698,6 +698,7 @@ function App() {
                 onRevealOutputFolder={handleRevealOutputFolder}
                 onPhotosLoadError={handlePhotosLoadError}
                 onPhotosLoadSuccess={clearPhotosIncident}
+                cdnBase={settings.cdnBase}
               />
             </ErrorBoundary>
           </div>

--- a/src/renderer/components/PhotoDetailModal.tsx
+++ b/src/renderer/components/PhotoDetailModal.tsx
@@ -11,6 +11,7 @@ import { Button } from '../components/ui/button';
 import { Chip } from '../components/ui/chip';
 import { Photo } from '../../shared/types';
 import { format } from 'date-fns';
+import { DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { ExtendedPhoto, usePhotoMetadata } from '../hooks/usePhotoMetadata';
 import { useFavorites } from '../hooks/useFavorites';
 
@@ -21,6 +22,7 @@ interface PhotoDetailModalProps {
   roomMap?: Map<string, string>;
   accountMap?: Map<string, string>;
   eventMap?: Map<string, string>;
+  cdnBase?: string;
 }
 
 const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
@@ -30,9 +32,10 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   roomMap = new Map(),
   accountMap = new Map(),
   eventMap = new Map(),
+  cdnBase = DEFAULT_CDN_BASE,
 }) => {
   const { getPhotoRoom, getPhotoUsers, getPhotoImageUrl, getPhotoEvent } =
-    usePhotoMetadata(roomMap, accountMap, eventMap);
+    usePhotoMetadata(roomMap, accountMap, eventMap, cdnBase);
   const { isFavorite, toggleFavorite } = useFavorites();
 
   if (!photo) return null;

--- a/src/renderer/components/PhotoGrid.tsx
+++ b/src/renderer/components/PhotoGrid.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Photo } from '../../shared/types';
 import { format } from 'date-fns';
+import { DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { usePhotoMetadata } from '../hooks/usePhotoMetadata';
 import { useFavorites } from '../hooks/useFavorites';
 
@@ -23,6 +24,7 @@ interface PhotoGridProps {
   roomMap?: Map<string, string>;
   accountMap?: Map<string, string>;
   eventMap?: Map<string, string>;
+  cdnBase?: string;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
   onScrollPositionChange?: (scrollTop: number) => void;
   className?: string;
@@ -38,6 +40,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
   roomMap = new Map(),
   accountMap = new Map(),
   eventMap = new Map(),
+  cdnBase = DEFAULT_CDN_BASE,
   scrollContainerRef: scrollContainerRefProp,
   onScrollPositionChange,
   className = '',
@@ -45,7 +48,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
 }) => {
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const { getPhotoRoom, getPhotoUsers, getPhotoImageUrl, getPhotoEvent } =
-    usePhotoMetadata(roomMap, accountMap, eventMap);
+    usePhotoMetadata(roomMap, accountMap, eventMap, cdnBase);
   const internalScrollRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = scrollContainerRefProp ?? internalScrollRef;
   const [containerSize, setContainerSize] = useState({ width: 0, height: 700 });

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -22,6 +22,7 @@ import {
   RoomDto,
   PlayerResult,
 } from '../../shared/types';
+import { DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { PhotoGrid } from './PhotoGrid';
 import { PhotoDetailModal } from './PhotoDetailModal';
 import { useFavorites } from '../hooks/useFavorites';
@@ -38,6 +39,7 @@ interface PhotoViewerProps {
   onRevealOutputFolder?: () => void;
   onPhotosLoadError?: (message: string) => void;
   onPhotosLoadSuccess?: () => void;
+  cdnBase?: string;
 }
 
 type PhotoSource = 'photos' | 'feed';
@@ -54,6 +56,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   onRevealOutputFolder,
   onPhotosLoadError,
   onPhotosLoadSuccess,
+  cdnBase = DEFAULT_CDN_BASE,
 }) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -549,6 +552,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
             roomMap={roomMap}
             accountMap={accountMap}
             eventMap={eventMap}
+            cdnBase={cdnBase}
             onScrollPositionChange={onScrollPositionChange}
             scrollContainerRef={activeScrollRef}
             accountId={accountId}
@@ -563,6 +567,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         roomMap={roomMap}
         accountMap={accountMap}
         eventMap={eventMap}
+        cdnBase={cdnBase}
       />
     </div>
   );

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -10,6 +10,11 @@ import {
   CardHeader,
   CardTitle,
 } from '../components/ui/card';
+import {
+  CDN_BASE_OPTIONS,
+  DEFAULT_CDN_BASE,
+  LEGACY_CDN_BASE,
+} from '../../shared/cdnUrl';
 import { RecNetSettings } from '../../shared/types';
 
 interface SettingsPanelProps {
@@ -29,11 +34,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [isSelectingFolder, setIsSelectingFolder] = useState(false);
 
   const handleSelectFolder = async () => {
-    if (!window.electronAPI) return;
+    const api = (window as unknown as { electronAPI?: any }).electronAPI;
+    if (!api) return;
 
     setIsSelectingFolder(true);
     try {
-      const folder = await window.electronAPI.selectOutputFolder();
+      const folder = await api.selectOutputFolder();
       if (folder) {
         await onUpdateSettings({ outputRoot: folder });
         onLog(`Output folder set to: ${folder}`, 'info');
@@ -42,6 +48,15 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       onLog(`Failed to select folder: ${error}`, 'error');
     } finally {
       setIsSelectingFolder(false);
+    }
+  };
+
+  const handleCdnChoice = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const selected = e.target.value;
+    if (CDN_BASE_OPTIONS.includes(selected as (typeof CDN_BASE_OPTIONS)[number])) {
+      await onUpdateSettings({ cdnBase: selected });
     }
   };
 
@@ -74,7 +89,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           Settings
         </CardTitle>
         <CardDescription>
-          Configure output path and request delays
+          Configure output path, image CDN, and request delays
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -97,6 +112,42 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             >
               <FolderOpen className="h-4 w-4" />
             </Button>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Image CDN</Label>
+          <div className="space-y-2">
+            <label className="flex items-start gap-2">
+              <input
+                type="radio"
+                name="cdnBase"
+                value={DEFAULT_CDN_BASE}
+                checked={settings.cdnBase === DEFAULT_CDN_BASE}
+                onChange={handleCdnChoice}
+              />
+              <span className="leading-5">
+                <span className="block text-sm font-medium">cdn.rec.net (recommended)</span>
+                <code className="block text-xs text-muted-foreground break-all">
+                  {DEFAULT_CDN_BASE}
+                </code>
+              </span>
+            </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="radio"
+                name="cdnBase"
+                value={LEGACY_CDN_BASE}
+                checked={settings.cdnBase === LEGACY_CDN_BASE}
+                onChange={handleCdnChoice}
+              />
+              <span className="leading-5">
+                <span className="block text-sm font-medium">img.rec.net (legacy)</span>
+                <code className="block text-xs text-muted-foreground break-all">
+                  {LEGACY_CDN_BASE}
+                </code>
+              </span>
+            </label>
           </div>
         </div>
 

--- a/src/renderer/hooks/usePhotoMetadata.ts
+++ b/src/renderer/hooks/usePhotoMetadata.ts
@@ -1,4 +1,8 @@
 import { useCallback, useMemo } from 'react';
+import {
+  buildCdnImageUrl,
+  DEFAULT_CDN_BASE,
+} from '../../shared/cdnUrl';
 import { Photo } from '../../shared/types';
 
 export interface PhotoEventInfo {
@@ -66,7 +70,8 @@ const getMapValue = (
 export const usePhotoMetadata = (
   roomMap?: Map<string, string>,
   accountMap?: Map<string, string>,
-  eventMap?: Map<string, string>
+  eventMap?: Map<string, string>,
+  cdnBase = DEFAULT_CDN_BASE
 ) => {
   const fallbackMap = useMemo(() => new Map<string, string>(), []);
   const safeRoomMap = roomMap ?? fallbackMap;
@@ -105,18 +110,21 @@ export const usePhotoMetadata = (
     [safeAccountMap]
   );
 
-  const getPhotoImageUrl = useCallback((photo: Photo): string => {
-    if (photo.localFilePath) {
-      const encodedPath = encodeURIComponent(photo.localFilePath);
-      return `local://${encodedPath}`;
-    }
+  const getPhotoImageUrl = useCallback(
+    (photo: Photo): string => {
+      if (photo.localFilePath) {
+        const encodedPath = encodeURIComponent(photo.localFilePath);
+        return `local://${encodedPath}`;
+      }
 
-    if (photo.ImageName) {
-      return `https://img.rec.net/${photo.ImageName}`;
-    }
+      if (photo.ImageName) {
+        return buildCdnImageUrl(cdnBase, photo.ImageName);
+      }
 
-    return '';
-  }, []);
+      return '';
+    },
+    [cdnBase]
+  );
 
   const getPhotoEvent = useCallback(
     (photo: Photo): PhotoEventInfo => {

--- a/src/shared/__tests__/cdnUrl.test.ts
+++ b/src/shared/__tests__/cdnUrl.test.ts
@@ -1,0 +1,32 @@
+import {
+  buildCdnImageUrl,
+  DEFAULT_CDN_BASE,
+} from '../cdnUrl';
+
+describe('buildCdnImageUrl', () => {
+  it('uses default cdn.rec.net/img base', () => {
+    expect(buildCdnImageUrl(DEFAULT_CDN_BASE, 'photo.jpg')).toBe(
+      'https://cdn.rec.net/img/photo.jpg'
+    );
+  });
+
+  it('supports legacy img.rec.net base (with or without trailing slash)', () => {
+    expect(buildCdnImageUrl('https://img.rec.net/', 'foo.png')).toBe(
+      'https://img.rec.net/foo.png'
+    );
+    expect(buildCdnImageUrl('https://img.rec.net', 'foo.png')).toBe(
+      'https://img.rec.net/foo.png'
+    );
+  });
+
+  it('strips {image_name} placeholder for backward compatibility', () => {
+    expect(buildCdnImageUrl('https://cdn.rec.net/img/{image_name}', 'a.jpg')).toBe(
+      'https://cdn.rec.net/img/a.jpg'
+    );
+  });
+
+  it('returns empty string when image name is empty', () => {
+    expect(buildCdnImageUrl(DEFAULT_CDN_BASE, '')).toBe('');
+    expect(buildCdnImageUrl(DEFAULT_CDN_BASE, '   ')).toBe('');
+  });
+});

--- a/src/shared/cdnUrl.ts
+++ b/src/shared/cdnUrl.ts
@@ -1,0 +1,32 @@
+/** Default Rec Room CDN base (preferred). */
+export const DEFAULT_CDN_BASE = 'https://cdn.rec.net/img/';
+
+/** Alternate legacy CDN base. */
+export const LEGACY_CDN_BASE = 'https://img.rec.net/';
+
+const PLACEHOLDER = '{image_name}';
+
+export const CDN_BASE_OPTIONS = [DEFAULT_CDN_BASE, LEGACY_CDN_BASE] as const;
+
+/**
+ * Builds a full image URL by appending `imageName` to a base URL.
+ *
+ * For backward compatibility, if the stored base includes `{image_name}`,
+ * that placeholder (and any trailing slash) is stripped first.
+ */
+export function buildCdnImageUrl(cdnBase: string, imageName: string): string {
+  const name = imageName.trim();
+  if (!name) {
+    return '';
+  }
+
+  const raw = cdnBase.trim();
+  const withoutPlaceholder = raw.includes(PLACEHOLDER)
+    ? raw.replace(PLACEHOLDER, '').replace(/\/+$/, '')
+    : raw;
+
+  const base = withoutPlaceholder.endsWith('/')
+    ? withoutPlaceholder
+    : `${withoutPlaceholder}/`;
+  return `${base}${name}`;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -7,8 +7,8 @@ export type { EventDto, ImageDto, PlayerResult, RoomDto };
 
 export interface RecNetSettings {
   outputRoot: string;
+  /** Image CDN base URL (image name is appended automatically). */
   cdnBase: string;
-  globalMaxConcurrentDownloads: number;
   interPageDelayMs: number;
   maxPhotosToDownload?: number; // Limit for testing - undefined means no limit
 }


### PR DESCRIPTION
- cleaned up unused settings
- added a new setting for choosing the CDN URL. Originally set to img.rec.net the user can now change it to cdn.rec.net (new default).  

Both cdn.rec.net and img.rec.net will download full resolution images.  cdn.rec.net should go through the CDN directly for images and use less resources on Rec Room's side. If there is any issues the user can always swap to use the other URL when downloading images.