### PR TITLE
Removed auth token and username match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rr-image-downloader",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "RR Image Downloader - Download Rec Room user images.",
   "main": "dist/main/main/main.js",
   "homepage": "./",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,6 +47,7 @@ interface CollectFeedPhotosParams {
 
 interface DownloadPhotosParams {
   accountId: string;
+  token?: string;
 }
 
 interface ApiResponse<T> {
@@ -373,7 +374,10 @@ ipcMain.handle(
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
     try {
-      const result = await recNetService.downloadPhotos(params.accountId);
+      const result = await recNetService.downloadPhotos(
+        params.accountId,
+        params.token
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -388,7 +392,10 @@ ipcMain.handle(
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
     try {
-      const result = await recNetService.downloadFeedPhotos(params.accountId);
+      const result = await recNetService.downloadFeedPhotos(
+        params.accountId,
+        params.token
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -455,13 +462,32 @@ ipcMain.handle(
   'search-accounts',
   async (
     event: IpcMainInvokeEvent,
-    username: string
+    username: string,
+    token?: string
   ): Promise<ApiResponse<AccountInfo[]>> => {
     try {
-      const result = await recNetService.searchAccounts(username);
+      const result = token
+        ? await recNetService.searchAccounts(username, token)
+        : await recNetService.searchAccounts(username);
       return { success: true, data: result };
     } catch (error) {
-      return { success: false, error: (error as Error).message };
+      const message = (error as Error).message ?? String(error);
+
+      // If the provided token isn't authorized, still allow downloads by
+      // falling back to unauthenticated account search.
+      if (token && /HTTP\s+(401|403)\b/.test(message)) {
+        try {
+          const result = await recNetService.searchAccounts(username);
+          return { success: true, data: result };
+        } catch (fallbackError) {
+          return {
+            success: false,
+            error: (fallbackError as Error).message ?? String(fallbackError),
+          };
+        }
+      }
+
+      return { success: false, error: message };
     }
   }
 );

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -24,7 +24,8 @@ const electronAPI: ElectronAPI = {
   },
 
   lookupAccount: (accountId) => ipcRenderer.invoke('lookup-account', accountId),
-  searchAccounts: (username) => ipcRenderer.invoke('search-accounts', username),
+  searchAccounts: (username: string, token?: string) =>
+    ipcRenderer.invoke('search-accounts', username, token),
   clearAccountData: (accountId) => ipcRenderer.invoke('clear-account-data', accountId),
 
   loadPhotos: (accountId) => ipcRenderer.invoke('load-photos', accountId),

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -831,7 +831,10 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadPhotos(accountId: string): Promise<DownloadResult> {
+  async downloadPhotos(
+    accountId: string,
+    token?: string
+  ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     this.currentOperation = { cancelled: false };
 
@@ -1002,7 +1005,7 @@ export class RecNetService extends EventEmitter {
         // Check if we've reached the download limit (only for new downloads)
         let attemptsUsed = 1;
         try {
-          const attempt = await this.downloadPhotoWithRetry(imageName);
+          const attempt = await this.downloadPhotoWithRetry(imageName, token);
           attemptsUsed = attempt.attempts;
           retryAttempts += Math.max(0, attempt.attempts - 1);
           if (
@@ -1100,7 +1103,10 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadFeedPhotos(accountId: string): Promise<DownloadResult> {
+  async downloadFeedPhotos(
+    accountId: string,
+    token?: string
+  ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     this.currentOperation = { cancelled: false };
 
@@ -1268,7 +1274,7 @@ export class RecNetService extends EventEmitter {
 
         let attemptsUsed = 1;
         try {
-          const attempt = await this.downloadPhotoWithRetry(imageName);
+          const attempt = await this.downloadPhotoWithRetry(imageName, token);
           attemptsUsed = attempt.attempts;
           retryAttempts += Math.max(0, attempt.attempts - 1);
           if (
@@ -1633,7 +1639,8 @@ export class RecNetService extends EventEmitter {
   }
 
   private async downloadPhotoWithRetry(
-    imageName: string
+    imageName: string,
+    token?: string
   ): Promise<PhotoDownloadAttempt> {
     let attempts = 0;
     let lastResponse: PhotoDownloadAttempt['response'];
@@ -1649,7 +1656,8 @@ export class RecNetService extends EventEmitter {
       try {
         const response = await this.photosController.downloadPhoto(
           imageName,
-          this.settings.cdnBase
+          this.settings.cdnBase,
+          token
         );
         if (response?.success && response.value) {
           if (attempts > 1) {
@@ -2115,9 +2123,12 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async searchAccounts(username: string): Promise<AccountInfo[]> {
+  async searchAccounts(
+    username: string,
+    token?: string
+  ): Promise<AccountInfo[]> {
     try {
-      return await this.accountsController.searchAccounts(username);
+      return await this.accountsController.searchAccounts(username, token);
     } catch (error) {
       throw new Error(`Failed to search accounts: ${(error as Error).message}`);
     }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -289,7 +289,10 @@ function App() {
 
         // Search for account by username
         addLog(`Searching for account: ${username}`, 'info');
-        const searchResult = await window.electronAPI.searchAccounts(username);
+        const searchResult = await window.electronAPI.searchAccounts(
+          username,
+          token.trim() || undefined
+        );
         if (
           !searchResult.success ||
           !searchResult.data ||
@@ -367,6 +370,7 @@ function App() {
         addLog('Step 2: Downloading photos...', 'info');
         const downloadResult = await window.electronAPI.downloadPhotos({
           accountId,
+          token: token.trim() || undefined,
         });
 
         if (!downloadResult.success) {
@@ -405,6 +409,7 @@ function App() {
         addLog('Step 3: Downloading feed photos...', 'info');
         const downloadFeedResult = await window.electronAPI.downloadFeedPhotos({
           accountId,
+          token: token.trim() || undefined,
         });
 
         if (!downloadFeedResult.success) {

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -67,7 +67,6 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     'idle' | 'checking' | 'valid' | 'invalid'
   >('idle');
   const [tokenExpiringSoon, setTokenExpiringSoon] = useState(false);
-  const [accountId, setAccountId] = useState<string | null>(null);
   const [tokenHelpOpen, setTokenHelpOpen] = useState(false);
   const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(
     null
@@ -123,55 +122,27 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     username,
   ]);
 
-  // Re-validate token when accountId changes
-  useEffect(() => {
-    if (token.trim() && accountId) {
-      // Clear existing timeout
-      if (tokenTimeout) {
-        clearTimeout(tokenTimeout);
-      }
-      const timeout = setTimeout(() => {
-        validateToken(token, accountId);
-      }, 300);
-      setTokenTimeout(timeout);
-    } else if (!accountId && token.trim()) {
-      setTokenStatus('invalid');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountId]);
-
   const checkUsername = async (value: string) => {
     if (!value.trim()) {
       setUsernameStatus('idle');
-      setAccountId(null);
       return;
     }
 
     setUsernameStatus('checking');
     try {
       if (electronAPI) {
-        const result = await electronAPI.searchAccounts(value);
+        const result = await electronAPI.searchAccounts(
+          value,
+          token.trim() || undefined
+        );
         if (result.success && result.data && result.data.length > 0) {
           setUsernameStatus('found');
-          const account = result.data[0];
-          const foundAccountId = account.accountId.toString();
-          setAccountId(foundAccountId);
-          // Re-validate token if it exists (useEffect will also handle this, but this provides immediate feedback)
-          if (token.trim()) {
-            const cleaned = cleanToken(token);
-            if (cleaned !== token) {
-              setToken(cleaned);
-            }
-            validateToken(cleaned, foundAccountId);
-          }
         } else {
           setUsernameStatus('not-found');
-          setAccountId(null);
         }
       }
     } catch (error) {
       setUsernameStatus('not-found');
-      setAccountId(null);
     }
   };
 
@@ -221,18 +192,9 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     return timeUntilExpiration <= twentyMinutesInMs && timeUntilExpiration > 0;
   };
 
-  const validateToken = (
-    tokenValue: string,
-    expectedAccountId: string | null
-  ) => {
+  const validateToken = (tokenValue: string) => {
     if (!tokenValue.trim()) {
       setTokenStatus('idle');
-      setTokenExpiringSoon(false);
-      return;
-    }
-
-    if (!expectedAccountId) {
-      setTokenStatus('invalid');
       setTokenExpiringSoon(false);
       return;
     }
@@ -244,10 +206,10 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       // Clean the token
       const cleaned = cleanToken(tokenValue);
 
-      // Decode the JWT
+      // Decode the JWT (no ownership/account checks)
       const decoded = decodeJWT(cleaned);
 
-      if (!decoded || !decoded.sub) {
+      if (!decoded) {
         setTokenStatus('invalid');
         setTokenExpiringSoon(false);
         return;
@@ -256,16 +218,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       // Check if token is expiring soon
       const isExpiringSoon = checkTokenExpiration(decoded);
       setTokenExpiringSoon(isExpiringSoon);
-
-      // Compare 'sub' with account ID
-      const tokenSub = decoded.sub.toString();
-      const accountIdStr = expectedAccountId.toString();
-
-      if (tokenSub === accountIdStr) {
-        setTokenStatus('valid');
-      } else {
-        setTokenStatus('invalid');
-      }
+      setTokenStatus('valid');
     } catch (error) {
       setTokenStatus('invalid');
       setTokenExpiringSoon(false);
@@ -333,11 +286,29 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
 
     // Debounce the validation
     const timeout = setTimeout(() => {
-      validateToken(cleaned, accountId);
+      validateToken(cleaned);
     }, 500);
 
     setTokenTimeout(timeout);
   };
+
+  // Re-check username existence when token changes, so optional auth
+  // is used for account lookup.
+  useEffect(() => {
+    if (!username.trim()) return;
+
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
+    }
+
+    const timeout = setTimeout(() => {
+      void checkUsername(username);
+    }, 1000);
+
+    setSearchTimeout(timeout);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
 
   const handleDownload = async () => {
     if (!username.trim() || !filePath.trim()) {
@@ -395,31 +366,6 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             </ol>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="username">Username</Label>
-            <Input
-              id="username"
-              placeholder="Enter your username"
-              value={username}
-              onChange={handleUsernameChange}
-            />
-            {usernameStatus === 'found' && (
-              <p className="text-sm text-green-600 dark:text-green-400">
-                Username found successfully
-              </p>
-            )}
-            {usernameStatus === 'not-found' && (
-              <p className="text-sm text-red-600 dark:text-red-400">
-                Username not found
-              </p>
-            )}
-            {usernameStatus === 'checking' && (
-              <p className="text-sm text-muted-foreground">
-                Checking username...
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Label htmlFor="token" className="flex items-center gap-2">
                 <Key className="h-4 w-4" />
@@ -446,13 +392,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             />
             {tokenStatus === 'valid' && (
               <p className="text-sm text-green-600 dark:text-green-400">
-                Token validated successfully - Account ID matches
+                Token validated successfully
               </p>
             )}
             {tokenStatus === 'invalid' && (
               <p className="text-sm text-red-600 dark:text-red-400">
-                Token validation failed - Account ID does not match or token is
-                invalid
+                Token is invalid or could not be parsed
               </p>
             )}
             {tokenStatus === 'checking' && (
@@ -462,14 +407,39 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             )}
             {tokenStatus === 'idle' && (
               <p className="text-sm text-muted-foreground">
-                Required if you want to download private photos as well as
-                public ones
+                Optional - required if you want to download private photos as well
+                as public ones
               </p>
             )}
             {tokenExpiringSoon && (
               <p className="text-sm text-red-600 dark:text-red-400">
                 Warning: Your token is expiring in 20 minutes or less. Please
                 get a fresh token (tokens last 1 hour).
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              placeholder="Enter your username"
+              value={username}
+              onChange={handleUsernameChange}
+            />
+            {usernameStatus === 'found' && (
+              <p className="text-sm text-green-600 dark:text-green-400">
+                Username found successfully
+              </p>
+            )}
+            {usernameStatus === 'not-found' && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                Username not found
+              </p>
+            )}
+            {usernameStatus === 'checking' && (
+              <p className="text-sm text-muted-foreground">
+                Checking username...
               </p>
             )}
           </div>

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -32,8 +32,8 @@ export interface ElectronAPI {
     forceRoomsRefresh?: boolean;
   }) => Promise<ApiResponse<CollectionResult>>;
 
-  downloadPhotos: (params: { accountId: string }) => Promise<ApiResponse<DownloadResult>>;
-  downloadFeedPhotos: (params: { accountId: string }) => Promise<ApiResponse<DownloadResult>>;
+  downloadPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;
+  downloadFeedPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;
 
   selectOutputFolder: () => Promise<string | null>;
   getSettings: () => Promise<RecNetSettings>;
@@ -44,7 +44,7 @@ export interface ElectronAPI {
   removeProgressListener: (callback: (event: unknown, progress: Progress) => void) => void;
 
   lookupAccount: (accountId: string) => Promise<ApiResponse<AccountInfo[]>>;
-  searchAccounts: (username: string) => Promise<ApiResponse<AccountInfo[]>>;
+  searchAccounts: (username: string, token?: string) => Promise<ApiResponse<AccountInfo[]>>;
   clearAccountData: (accountId: string) => Promise<ApiResponse<{ filesRemoved: number }>>;
   loadPhotos: (accountId: string) => Promise<ApiResponse<Photo[]>>;
   loadFeedPhotos: (accountId: string) => Promise<ApiResponse<Photo[]>>;


### PR DESCRIPTION
Removed bearer token and username match requirement. This was a required change for anyone looking to download photos from a junior account.  And in all honesty there is no reason to block someone from using their own token when downloading photos from another account.