### PR TITLE
fix: removed user token from cdn.rec.net requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rr-image-downloader",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "RR Image Downloader - Download Rec Room user images.",
   "main": "dist/main/main/main.js",
   "homepage": "./",

--- a/src/main/services/recnet/photos-controller.ts
+++ b/src/main/services/recnet/photos-controller.ts
@@ -1,4 +1,7 @@
-import { buildCdnImageUrl } from '../../../shared/cdnUrl';
+import {
+  buildCdnImageUrl,
+  shouldIncludeTokenForCdnBase,
+} from '../../../shared/cdnUrl';
 import { ImageDto } from '../../models/ImageDto';
 import { GenericResponse } from '../../models/GenericResponse';
 import { RecNetHttpClient } from './http-client';
@@ -38,13 +41,16 @@ export class PhotosController {
     token?: string
   ): Promise<GenericResponse<ArrayBuffer>> {
     const url = buildCdnImageUrl(cdnBase, imageName);
+    const tokenForRequest = shouldIncludeTokenForCdnBase(cdnBase)
+      ? token
+      : undefined;
     return this.http.request<ArrayBuffer>(
       {
         url,
         method: 'GET',
         responseType: 'arraybuffer',
       },
-      token
+      tokenForRequest
     );
   }
 }

--- a/src/shared/__tests__/cdnUrl.test.ts
+++ b/src/shared/__tests__/cdnUrl.test.ts
@@ -1,6 +1,7 @@
 import {
   buildCdnImageUrl,
   DEFAULT_CDN_BASE,
+  shouldIncludeTokenForCdnBase,
 } from '../cdnUrl';
 
 describe('buildCdnImageUrl', () => {
@@ -28,5 +29,16 @@ describe('buildCdnImageUrl', () => {
   it('returns empty string when image name is empty', () => {
     expect(buildCdnImageUrl(DEFAULT_CDN_BASE, '')).toBe('');
     expect(buildCdnImageUrl(DEFAULT_CDN_BASE, '   ')).toBe('');
+  });
+});
+
+describe('shouldIncludeTokenForCdnBase', () => {
+  it('returns false for cdn.rec.net', () => {
+    expect(shouldIncludeTokenForCdnBase('https://cdn.rec.net/img/')).toBe(false);
+    expect(shouldIncludeTokenForCdnBase('cdn.rec.net/img')).toBe(false);
+  });
+
+  it('returns true for img.rec.net', () => {
+    expect(shouldIncludeTokenForCdnBase('https://img.rec.net/')).toBe(true);
   });
 });

--- a/src/shared/cdnUrl.ts
+++ b/src/shared/cdnUrl.ts
@@ -30,3 +30,26 @@ export function buildCdnImageUrl(cdnBase: string, imageName: string): string {
     : `${withoutPlaceholder}/`;
   return `${base}${name}`;
 }
+
+/**
+ * Returns true when image requests should include the user token.
+ *
+ * `cdn.rec.net` must not receive auth tokens because it returns 403 when
+ * Authorization is present. `img.rec.net` still accepts authenticated requests.
+ */
+export function shouldIncludeTokenForCdnBase(cdnBase: string): boolean {
+  const raw = cdnBase.trim();
+  if (!raw) {
+    return true;
+  }
+
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+
+  try {
+    const hostname = new URL(candidate).hostname.toLowerCase();
+    return hostname !== 'cdn.rec.net';
+  } catch {
+    // Preserve historical behavior if a custom value cannot be parsed.
+    return true;
+  }
+}


### PR DESCRIPTION
Tokens can be included when calling img.rec.net but not for cdn.rec.net.  If a token was included it would result in a 403 regardless of if it was valid or not.