### PR TITLE
Modified Download Flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rr-image-downloader",
-  "version": "3.5.8",
+  "version": "3.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rr-image-downloader",
-      "version": "3.5.8",
+      "version": "3.9.4",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
@@ -14,6 +14,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "axios": "^1.6.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5329,6 +5330,58 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "axios": "^1.6.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,6 +4,7 @@ import {
   ipcMain,
   dialog,
   IpcMainInvokeEvent,
+  Menu,
   protocol,
   shell,
 } from 'electron';
@@ -124,6 +125,34 @@ const normalizeEventRecord = (event: EventDto): EventDto => ({
   RoomId: normalizeId(event.RoomId),
 });
 
+function attachEditableContextMenu(win: BrowserWindow): void {
+  win.webContents.on('context-menu', (_event, params) => {
+    const { editFlags, isEditable, selectionText } = params;
+    const template: Electron.MenuItemConstructorOptions[] = [];
+
+    if (isEditable) {
+      template.push(
+        { role: 'undo', enabled: editFlags.canUndo },
+        { role: 'redo', enabled: editFlags.canRedo },
+        { type: 'separator' },
+        { role: 'cut', enabled: editFlags.canCut },
+        { role: 'copy', enabled: editFlags.canCopy },
+        { role: 'paste', enabled: editFlags.canPaste },
+        { type: 'separator' },
+        { role: 'selectAll', enabled: editFlags.canSelectAll }
+      );
+    } else if ((selectionText ?? '').trim()) {
+      template.push({ role: 'copy', enabled: editFlags.canCopy });
+    }
+
+    if (template.length === 0) {
+      return;
+    }
+
+    Menu.buildFromTemplate(template).popup({ window: win });
+  });
+}
+
 function createWindow(): void {
   // Create the browser window
   mainWindow = new BrowserWindow({
@@ -184,6 +213,8 @@ function createWindow(): void {
   if (isDev) {
     mainWindow.webContents.openDevTools();
   }
+
+  attachEditableContextMenu(mainWindow);
 
   // Handle window closed
   mainWindow.on('closed', () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { RecNetService } from './services/recnet-service';
 import {
   CollectionResult,
   DownloadResult,
+  ProfileHistoryAccessResult,
   RecNetSettings,
   Progress,
   AccountInfo,
@@ -48,6 +49,11 @@ interface CollectFeedPhotosParams {
 interface DownloadPhotosParams {
   accountId: string;
   token?: string;
+}
+
+interface ValidateProfileHistoryAccessParams {
+  username: string;
+  token: string;
 }
 
 interface ApiResponse<T> {
@@ -374,7 +380,10 @@ ipcMain.handle(
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
     try {
-      const result = await recNetService.downloadPhotos(params.accountId);
+      const result = await recNetService.downloadPhotos(
+        params.accountId,
+        params.token
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -389,7 +398,46 @@ ipcMain.handle(
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
     try {
-      const result = await recNetService.downloadFeedPhotos(params.accountId);
+      const result = await recNetService.downloadFeedPhotos(
+        params.accountId,
+        params.token
+      );
+      return { success: true, data: result };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+);
+
+ipcMain.handle(
+  'download-profile-history',
+  async (
+    event: IpcMainInvokeEvent,
+    params: ValidateProfileHistoryAccessParams & { accountId: string }
+  ): Promise<ApiResponse<DownloadResult>> => {
+    try {
+      const result = await recNetService.downloadProfileHistory(
+        params.accountId,
+        params.token
+      );
+      return { success: true, data: result };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+);
+
+ipcMain.handle(
+  'validate-profile-history-access',
+  async (
+    event: IpcMainInvokeEvent,
+    params: ValidateProfileHistoryAccessParams
+  ): Promise<ApiResponse<ProfileHistoryAccessResult>> => {
+    try {
+      const result = await recNetService.validateProfileHistoryAccess(
+        params.username,
+        params.token
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -456,13 +504,29 @@ ipcMain.handle(
   'lookup-account-by-username',
   async (
     event: IpcMainInvokeEvent,
-    username: string
+    username: string,
+    token?: string
   ): Promise<ApiResponse<AccountInfo>> => {
     try {
-      const result = await recNetService.lookupAccountByUsername(username);
+      const result = await recNetService.lookupAccountByUsername(username, token);
       return { success: true, data: result };
     } catch (error) {
-      return { success: false, error: (error as Error).message };
+      const message = (error as Error).message ?? String(error);
+
+      if (token && /HTTP\s+(401|403)\b/.test(message)) {
+        try {
+          const fallback = await recNetService.lookupAccountByUsername(username);
+          return { success: true, data: fallback };
+        } catch (fallbackError) {
+          return {
+            success: false,
+            error:
+              (fallbackError as Error).message ?? String(fallbackError),
+          };
+        }
+      }
+
+      return { success: false, error: message };
     }
   }
 );
@@ -671,6 +735,64 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'load-profile-history-photos',
+  async (
+    event: IpcMainInvokeEvent,
+    accountId: string
+  ): Promise<ApiResponse<Photo[]>> => {
+    try {
+      const settings = await recNetService.getSettings();
+      const accountDir = path.join(settings.outputRoot, accountId);
+      const profileHistoryJsonPath = path.join(
+        accountDir,
+        `${accountId}_profile_history.json`
+      );
+
+      if (!(await fs.pathExists(profileHistoryJsonPath))) {
+        return { success: true, data: [] };
+      }
+
+      const profileHistoryPhotos: Photo[] = (await fs.readJson(
+        profileHistoryJsonPath
+      )).map(normalizePhotoRecord);
+      const profileHistoryDir = path.join(accountDir, 'profile-history');
+
+      const profileHistoryFileIds = new Set<string>();
+      if (await fs.pathExists(profileHistoryDir)) {
+        const files = await fs.readdir(profileHistoryDir);
+        for (const file of files) {
+          const id = path.parse(file).name;
+          if (id) {
+            profileHistoryFileIds.add(id);
+          }
+        }
+      }
+
+      const photosWithFiles: Photo[] = [];
+      for (const photo of profileHistoryPhotos) {
+        if (!photo.Id) {
+          continue;
+        }
+
+        const photoId = photo.Id.toString();
+        if (!profileHistoryFileIds.has(photoId)) {
+          continue;
+        }
+
+        photosWithFiles.push({
+          ...photo,
+          localFilePath: path.join(profileHistoryDir, `${photoId}.jpg`),
+        });
+      }
+
+      return { success: true, data: photosWithFiles };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+);
+
 // List available accounts with metadata
 ipcMain.handle(
   'list-available-accounts',
@@ -680,8 +802,10 @@ ipcMain.handle(
         accountId: string;
         hasPhotos: boolean;
         hasFeed: boolean;
+        hasProfileHistory: boolean;
         photoCount: number;
         feedCount: number;
+        profileHistoryCount: number;
         displayLabel?: string;
       }>
     >

--- a/src/main/models/ProfileHistoryImageDto.ts
+++ b/src/main/models/ProfileHistoryImageDto.ts
@@ -1,0 +1,15 @@
+export interface ProfileHistoryImageDto {
+  Id: string | number;
+  Type: number;
+  Accessibility: number;
+  AccessibilityLocked: boolean;
+  ImageName: string;
+  Description: string | null;
+  PlayerId: string | number;
+  TaggedPlayerIds: Array<string | number>;
+  RoomId: string | number | null;
+  PlayerEventId: string | number | null;
+  CreatedAt: string;
+  CheerCount: number;
+  CommentCount: number;
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -7,6 +7,10 @@ const electronAPI: ElectronAPI = {
 
   downloadPhotos: (params) => ipcRenderer.invoke('download-photos', params),
   downloadFeedPhotos: (params) => ipcRenderer.invoke('download-feed-photos', params),
+  downloadProfileHistory: (params) =>
+    ipcRenderer.invoke('download-profile-history', params),
+  validateProfileHistoryAccess: (params) =>
+    ipcRenderer.invoke('validate-profile-history-access', params),
 
   selectOutputFolder: () => ipcRenderer.invoke('select-output-folder'),
 
@@ -24,14 +28,16 @@ const electronAPI: ElectronAPI = {
   },
 
   lookupAccountById: (accountId) => ipcRenderer.invoke('lookup-account-by-id', accountId),
-  lookupAccountByUsername: (username: string) =>
-    ipcRenderer.invoke('lookup-account-by-username', username),
+  lookupAccountByUsername: (username: string, token?: string) =>
+    ipcRenderer.invoke('lookup-account-by-username', username, token),
   searchAccounts: (username: string, token?: string) =>
     ipcRenderer.invoke('search-accounts', username, token),
   clearAccountData: (accountId) => ipcRenderer.invoke('clear-account-data', accountId),
 
   loadPhotos: (accountId) => ipcRenderer.invoke('load-photos', accountId),
   loadFeedPhotos: (accountId) => ipcRenderer.invoke('load-feed-photos', accountId),
+  loadProfileHistoryPhotos: (accountId) =>
+    ipcRenderer.invoke('load-profile-history-photos', accountId),
   listAvailableAccounts: () => ipcRenderer.invoke('list-available-accounts'),
   loadAccountsData: (accountId) => ipcRenderer.invoke('load-accounts-data', accountId),
   loadRoomsData: (accountId) => ipcRenderer.invoke('load-rooms-data', accountId),

--- a/src/main/services/__tests__/recnet-service.download.test.ts
+++ b/src/main/services/__tests__/recnet-service.download.test.ts
@@ -51,6 +51,13 @@ describe('RecNetService - Download Functionality', () => {
   let testAccountId: string;
   let mockPhotosController: jest.Mocked<PhotosController>;
 
+  const createJwt = (payload: Record<string, unknown>): string => {
+    const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      .toString('base64url');
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    return `${header}.${body}.signature`;
+  };
+
   beforeEach(() => {
     // Create a unique test directory for each test
     testOutputDir = path.join(__dirname, 'test-output', `test-${Date.now()}`);
@@ -69,6 +76,7 @@ describe('RecNetService - Download Functionality', () => {
       downloadPhoto: jest.fn(),
       fetchPlayerPhotos: jest.fn(),
       fetchFeedPhotos: jest.fn(),
+      fetchProfilePhotoHistory: jest.fn(),
     } as any;
 
     // Replace the photosController with our mock
@@ -1008,6 +1016,220 @@ describe('RecNetService - Download Functionality', () => {
       await expect(service.downloadFeedPhotos(testAccountId)).rejects.toThrow(
         'Operation cancelled'
       );
+    });
+  });
+
+  describe('validateProfileHistoryAccess', () => {
+    it('rejects malformed JWT tokens', async () => {
+      await expect(
+        service.validateProfileHistoryAccess('test-user', 'not-a-jwt')
+      ).rejects.toThrow('Token is invalid or could not be parsed.');
+    });
+
+    it('rejects expired JWT tokens', async () => {
+      const expiredToken = createJwt({
+        sub: testAccountId,
+        exp: Math.floor(Date.now() / 1000) - 60,
+      });
+
+      await expect(
+        service.validateProfileHistoryAccess('test-user', expiredToken)
+      ).rejects.toThrow('Token has expired.');
+    });
+
+    it('rejects when the username cannot be resolved', async () => {
+      const token = createJwt({
+        sub: testAccountId,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      const mockAccountsController = (
+        service as unknown as {
+          accountsController: { lookupAccountByUsername: jest.Mock };
+        }
+      ).accountsController;
+
+      mockAccountsController.lookupAccountByUsername.mockRejectedValue(
+        new Error('HTTP 404: Not found')
+      );
+
+      await expect(
+        service.validateProfileHistoryAccess('missing-user', token)
+      ).rejects.toThrow('Failed to lookup account by username: HTTP 404: Not found');
+    });
+
+    it('rejects when the token belongs to a different user', async () => {
+      const token = createJwt({
+        sub: 'someone-else',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      const mockAccountsController = (
+        service as unknown as {
+          accountsController: { lookupAccountByUsername: jest.Mock };
+        }
+      ).accountsController;
+
+      mockAccountsController.lookupAccountByUsername.mockResolvedValue({
+        accountId: testAccountId,
+        username: 'test-user',
+        displayName: 'Test User',
+      });
+
+      await expect(
+        service.validateProfileHistoryAccess('test-user', token)
+      ).rejects.toThrow('Token does not belong to this user.');
+    });
+
+    it('validates matching tokens and confirms profile history access', async () => {
+      const token = createJwt({
+        sub: testAccountId,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      const mockAccountsController = (
+        service as unknown as {
+          accountsController: { lookupAccountByUsername: jest.Mock };
+        }
+      ).accountsController;
+
+      mockAccountsController.lookupAccountByUsername.mockResolvedValue({
+        accountId: testAccountId,
+        username: 'test-user',
+        displayName: 'Test User',
+      });
+      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue([]);
+
+      const result = await service.validateProfileHistoryAccess(
+        'test-user',
+        token
+      );
+
+      expect(result).toEqual({
+        accountId: testAccountId,
+        username: 'test-user',
+        tokenAccountId: testAccountId,
+      });
+      expect(mockPhotosController.fetchProfilePhotoHistory).toHaveBeenCalledWith(
+        token
+      );
+    });
+  });
+
+  describe('downloadProfileHistory', () => {
+    const createProfileHistoryEntry = (id: number, imageName: string) => ({
+      Id: id,
+      Type: 4,
+      Accessibility: 0,
+      AccessibilityLocked: false,
+      ImageName: imageName,
+      Description: null,
+      PlayerId: 256147,
+      TaggedPlayerIds: [],
+      RoomId: 517859,
+      PlayerEventId: null,
+      CreatedAt: new Date().toISOString(),
+      CheerCount: 0,
+      CommentCount: 0,
+    });
+
+    it('saves the manifest and downloads profile history images', async () => {
+      const historyPayload = [
+        createProfileHistoryEntry(85498573, 'avatar1.jpg'),
+        createProfileHistoryEntry(85498574, 'avatar2.jpg'),
+      ];
+      const profileHistoryDir = path.join(
+        testOutputDir,
+        testAccountId,
+        'profile-history'
+      );
+      const manifestPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_profile_history.json`
+      );
+
+      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: true,
+        value: new ArrayBuffer(512),
+        status: 200,
+      } as GenericResponse<ArrayBuffer>);
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.downloadProfileHistory(testAccountId, 'token');
+
+      expect(result.profileHistoryDirectory).toBe(profileHistoryDir);
+      expect(result.profileHistoryManifestPath).toBe(manifestPath);
+      expect(result.downloadStats.newDownloads).toBe(2);
+      expect(mockedFs.writeJson).toHaveBeenCalledWith(
+        manifestPath,
+        historyPayload,
+        { spaces: 2 }
+      );
+      expect(mockedFs.writeFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips already-downloaded profile history images on rerun', async () => {
+      const historyPayload = [createProfileHistoryEntry(85498573, 'avatar1.jpg')];
+      const existingPhotoPath = path.join(
+        testOutputDir,
+        testAccountId,
+        'profile-history',
+        '85498573.jpg'
+      );
+
+      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === existingPhotoPath) {
+          return true;
+        }
+        return false;
+      });
+      (mockedFs.readdir as jest.Mock).mockResolvedValue(['85498573.jpg']);
+
+      const result = await service.downloadProfileHistory(testAccountId, 'token');
+
+      expect(result.downloadStats.alreadyDownloaded).toBe(1);
+      expect(result.downloadStats.newDownloads).toBe(0);
+      expect(mockPhotosController.downloadPhoto).not.toHaveBeenCalled();
+    });
+
+    it('retries failed profile history downloads before reporting failure', async () => {
+      const historyPayload = [createProfileHistoryEntry(85498573, 'avatar1.jpg')];
+
+      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: false,
+        value: null,
+        status: 500,
+        error: 'CDN failure',
+      } as GenericResponse<ArrayBuffer>);
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.downloadProfileHistory(testAccountId, 'token');
+
+      expect(result.downloadStats.failedDownloads).toBe(1);
+      expect(result.downloadStats.retryAttempts).toBe(3);
+      expect(result.downloadResults[0].attempts).toBe(4);
+      expect(result.guidance?.[0]).toContain('profile picture history images');
+      expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(4);
+    });
+
+    it('rejects when no token is provided', async () => {
+      await expect(
+        service.downloadProfileHistory(testAccountId, '')
+      ).rejects.toThrow('Profile picture history requires a valid access token.');
+    });
+
+    it('rejects unauthorized profile history requests', async () => {
+      mockPhotosController.fetchProfilePhotoHistory.mockRejectedValue(
+        new Error('HTTP 401: Unauthorized')
+      );
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+
+      await expect(
+        service.downloadProfileHistory(testAccountId, 'token')
+      ).rejects.toThrow('HTTP 401: Unauthorized');
     });
   });
 });

--- a/src/main/services/__tests__/recnet-service.listAvailableAccounts.test.ts
+++ b/src/main/services/__tests__/recnet-service.listAvailableAccounts.test.ts
@@ -85,8 +85,10 @@ describe('RecNetService - listAvailableAccounts (folder meta)', () => {
         accountId,
         hasPhotos: true,
         hasFeed: false,
+        hasProfileHistory: false,
         photoCount: 1,
         feedCount: 0,
+        profileHistoryCount: 0,
         displayLabel: 'Alice (@alice)',
       },
     ]);
@@ -200,6 +202,42 @@ describe('RecNetService - listAvailableAccounts (folder meta)', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('includes accounts that only have profile history metadata', async () => {
+    const accountId = '256147';
+    const accountDir = path.join(testOutputDir, accountId);
+    const profileHistoryJsonPath = path.join(
+      accountDir,
+      `${accountId}_profile_history.json`
+    );
+
+    (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+      if (p === testOutputDir) return true;
+      if (p === profileHistoryJsonPath) return true;
+      return false;
+    });
+
+    (mockedFs.readdir as jest.Mock).mockResolvedValue([makeDirent(accountId)]);
+    (mockedFs.readJson as jest.Mock).mockImplementation(async (p: string) => {
+      if (p === profileHistoryJsonPath) return [{ Id: '1' }];
+      throw new Error(`Unexpected readJson(${p})`);
+    });
+
+    const result = await service.listAvailableAccounts();
+
+    expect(result).toEqual([
+      {
+        accountId,
+        hasPhotos: false,
+        hasFeed: false,
+        hasProfileHistory: true,
+        photoCount: 0,
+        feedCount: 0,
+        profileHistoryCount: 1,
+        displayLabel: undefined,
+      },
+    ]);
   });
 });
 

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -7,6 +7,7 @@ import {
   Progress,
   CollectionResult,
   DownloadResult,
+  ProfileHistoryAccessResult,
   Photo,
   IterationDetail,
   DownloadResultItem,
@@ -18,6 +19,7 @@ import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { EventDto } from '../models/EventDto';
 import { ImageDto } from '../models/ImageDto';
 import { PlayerResult } from '../models/PlayerDto';
+import { ProfileHistoryImageDto } from '../models/ProfileHistoryImageDto';
 import { RoomDto } from '../models/RoomDto';
 import { AccountsController } from './recnet/accounts-controller';
 import { EventsController } from './recnet/events-controller';
@@ -42,6 +44,11 @@ interface PhotoDownloadAttempt {
   error?: Error;
   attempts: number;
 }
+
+type JwtPayload = {
+  sub?: string;
+  exp?: number;
+};
 
 type FolderMetaOwner = {
   accountId: string;
@@ -898,7 +905,7 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadPhotos(accountId: string): Promise<DownloadResult> {
+  async downloadPhotos(accountId: string, token?: string): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     const operation = this.startOperation();
 
@@ -1041,7 +1048,7 @@ export class RecNetService extends EventEmitter {
                     photosDir,
                     feedDir,
                     false,
-                    undefined,
+                    token,
                     operation
                   );
                   const status = result.status;
@@ -1141,7 +1148,10 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadFeedPhotos(accountId: string): Promise<DownloadResult> {
+  async downloadFeedPhotos(
+    accountId: string,
+    token?: string
+  ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     if (this.currentOperation?.cancelled) {
       throw this.createOperationCancelledError();
@@ -1290,7 +1300,7 @@ export class RecNetService extends EventEmitter {
                     photosDir,
                     feedPhotosDir,
                     true,
-                    undefined,
+                    token,
                     operation
                   );
                   const status = result.status;
@@ -1379,6 +1389,327 @@ export class RecNetService extends EventEmitter {
         downloadResults,
         totalResults: downloadResults.length,
         guidance: this.buildDownloadGuidance('feed photos', downloadStats),
+      };
+    } catch (error) {
+      if (!this.isOperationCancelledError(error)) {
+        this.setOperationFailed((error as Error).message);
+      }
+      throw error;
+    } finally {
+      this.finishOperation(operation);
+    }
+  }
+
+  async validateProfileHistoryAccess(
+    username: string,
+    token: string
+  ): Promise<ProfileHistoryAccessResult> {
+    const cleanedUsername = username.trim();
+    const cleanedToken = token.trim();
+
+    if (!cleanedUsername) {
+      throw new Error('Username is required.');
+    }
+    if (!cleanedToken) {
+      throw new Error('Access token is required for profile picture history.');
+    }
+
+    const payload = this.decodeJwtPayload(cleanedToken);
+    if (!payload) {
+      throw new Error('Token is invalid or could not be parsed.');
+    }
+    if (!payload.sub) {
+      throw new Error('Token is missing an account id.');
+    }
+    if (payload.exp && payload.exp * 1000 <= Date.now()) {
+      throw new Error('Token has expired.');
+    }
+
+    const account = await this.lookupAccountByUsername(cleanedUsername);
+    const accountId = this.normalizeId(account.accountId);
+    const tokenAccountId = this.normalizeId(payload.sub);
+
+    if (!accountId) {
+      throw new Error('Could not resolve an account id for this username.');
+    }
+    if (tokenAccountId !== accountId) {
+      throw new Error('Token does not belong to this user.');
+    }
+
+    try {
+      await this.photosController.fetchProfilePhotoHistory(cleanedToken);
+    } catch (error) {
+      const message = (error as Error).message ?? String(error);
+      if (/HTTP\s+(401|403)\b/.test(message)) {
+        throw new Error(
+          'Token is not authorized to access profile picture history.'
+        );
+      }
+      throw error;
+    }
+
+    return {
+      accountId,
+      username: (account.username || cleanedUsername).trim(),
+      tokenAccountId,
+    };
+  }
+
+  async downloadProfileHistory(
+    accountId: string,
+    token: string
+  ): Promise<DownloadResult> {
+    await this.ensureSettingsLoaded();
+    if (this.currentOperation?.cancelled) {
+      throw this.createOperationCancelledError();
+    }
+    const operation = this.startOperation();
+
+    try {
+      this.resetProgressIssueState();
+      this.updateProgress('Downloading profile picture history...', 0, 0, 0);
+
+      const cleanedToken = token.trim();
+      if (!cleanedToken) {
+        throw new Error(
+          'Profile picture history requires a valid access token.'
+        );
+      }
+
+      const requestOptions = { signal: operation.controller.signal };
+      const historyPayload = await this.photosController.fetchProfilePhotoHistory(
+        cleanedToken,
+        requestOptions
+      );
+
+      if (operation.cancelled) {
+        throw this.createOperationCancelledError();
+      }
+
+      const accountDir = path.join(this.settings.outputRoot, accountId);
+      await fs.ensureDir(accountDir);
+
+      const manifestPath = path.join(
+        accountDir,
+        `${accountId}_profile_history.json`
+      );
+      await fs.writeJson(manifestPath, historyPayload, { spaces: 2 });
+
+      const profileHistoryDir = path.join(accountDir, 'profile-history');
+      await fs.ensureDir(profileHistoryDir);
+
+      const profilePhotos = this.normalizeProfileHistoryPhotos(
+        historyPayload,
+        accountId
+      );
+      const totalPhotos = profilePhotos.length;
+      const maxPhotosToDownload = this.settings.maxPhotosToDownload;
+      const hasDownloadLimit = maxPhotosToDownload && maxPhotosToDownload > 0;
+
+      const existingFiles = (await fs.readdir(profileHistoryDir)).filter(file =>
+        file.toLowerCase().endsWith('.jpg')
+      ).length;
+      let remainingDownloadSlots =
+        (maxPhotosToDownload || 0) - existingFiles;
+
+      if (hasDownloadLimit && remainingDownloadSlots <= 0) {
+        this.updateProgress(
+          'Download limit reached for profile picture history',
+          totalPhotos,
+          totalPhotos,
+          100
+        );
+        this.setOperationComplete();
+        return {
+          accountId,
+          profileHistoryDirectory: profileHistoryDir,
+          profileHistoryManifestPath: manifestPath,
+          processedCount: 0,
+          downloadStats: {
+            totalPhotos,
+            alreadyDownloaded: existingFiles,
+            newDownloads: 0,
+            failedDownloads: 0,
+            skipped: totalPhotos,
+            retryAttempts: 0,
+            recoveredAfterRetry: 0,
+          },
+          downloadResults: [],
+          totalResults: 0,
+        };
+      }
+
+      if (totalPhotos === 0) {
+        this.setOperationComplete();
+        return {
+          accountId,
+          profileHistoryDirectory: profileHistoryDir,
+          profileHistoryManifestPath: manifestPath,
+          processedCount: 0,
+          downloadStats: {
+            totalPhotos: 0,
+            alreadyDownloaded: 0,
+            newDownloads: 0,
+            failedDownloads: 0,
+            skipped: 0,
+            retryAttempts: 0,
+            recoveredAfterRetry: 0,
+          },
+          downloadResults: [],
+          totalResults: 0,
+        };
+      }
+
+      const trace = this.createDownloadBatchTrace(
+        'profile-history-downloads',
+        totalPhotos
+      );
+      let alreadyDownloaded = 0;
+      let newDownloads = 0;
+      let failedDownloads = 0;
+      let skipped = 0;
+      let retryAttempts = 0;
+      let recoveredAfterRetry = 0;
+      let processedCount = 0;
+
+      this.updateProgress(
+        'Downloading profile picture history...',
+        0,
+        totalPhotos,
+        0
+      );
+
+      let delay = 0;
+      const promises: Array<Promise<DownloadResultItem>> = [];
+      const semaphore = new Semaphore(this.settings.maxConcurrentDownloads);
+      let scheduledPhotoCount = 0;
+
+      for (const photo of profilePhotos) {
+        if (hasDownloadLimit && remainingDownloadSlots <= 0) {
+          skipped = profilePhotos.length - scheduledPhotoCount;
+          break;
+        } else {
+          remainingDownloadSlots--;
+        }
+
+        scheduledPhotoCount++;
+        const scheduledIndex = scheduledPhotoCount;
+        const scheduledDelayMs = delay;
+        promises.push(
+          new Promise<DownloadResultItem>((resolve, reject) => {
+            void (async () => {
+              const photoId = this.normalizeId(photo.Id);
+              const imageName = photo.ImageName;
+              const runStartedAt = Date.now();
+              let result: DownloadResultItem | undefined;
+
+              try {
+                if (scheduledDelayMs) {
+                  await this.delay(scheduledDelayMs, operation);
+                }
+
+                const slotWaitStartedAt = Date.now();
+                await semaphore.acquire();
+                const slotWaitMs = Date.now() - slotWaitStartedAt;
+                trace.inFlight++;
+                this.logDownloadWorkerStart(trace, {
+                  scheduledIndex,
+                  photoId,
+                  imageName,
+                  scheduledDelayMs,
+                  slotWaitMs,
+                });
+
+                try {
+                  result = await this.downloadProfileHistoryImage(
+                    photo,
+                    profileHistoryDir,
+                    cleanedToken,
+                    operation
+                  );
+                  const status = result.status;
+
+                  if (status === 'downloaded') {
+                    newDownloads++;
+                    retryAttempts += (result.attempts || 1) - 1;
+                    if (result.recoveredAfterRetry) {
+                      recoveredAfterRetry++;
+                    }
+                  } else if (status && status.startsWith('already_exists')) {
+                    alreadyDownloaded++;
+                  } else if (
+                    status &&
+                    (status === 'error' || status === 'failed')
+                  ) {
+                    failedDownloads++;
+                    retryAttempts += (result.attempts || 1) - 1;
+                  } else if (status === 'cancelled') {
+                    skipped++;
+                  }
+
+                  resolve(result);
+                } catch (error) {
+                  reject(error);
+                } finally {
+                  trace.inFlight = Math.max(0, trace.inFlight - 1);
+                  trace.completed++;
+                  this.logDownloadWorkerFinish(trace, {
+                    scheduledIndex,
+                    photoId,
+                    imageName,
+                    result,
+                    runDurationMs: Date.now() - runStartedAt,
+                  });
+                  semaphore.release();
+                  if (this.currentOperation === operation) {
+                    this.updateProgress(
+                      'Downloading profile picture history...',
+                      processedCount,
+                      totalPhotos
+                    );
+                    processedCount++;
+                  }
+                }
+              } catch (error) {
+                reject(error);
+              }
+            })();
+          })
+        );
+        delay += this.settings.interPageDelayMs || 0;
+      }
+
+      const downloadResults = await Promise.all<DownloadResultItem>(promises);
+
+      if (operation.cancelled) {
+        throw this.createOperationCancelledError();
+      }
+
+      this.setOperationComplete();
+
+      const downloadStats: DownloadStats = {
+        totalPhotos,
+        alreadyDownloaded,
+        newDownloads,
+        failedDownloads,
+        skipped,
+        retryAttempts,
+        recoveredAfterRetry,
+      };
+      this.logDownloadBatchSummary(trace, downloadStats);
+
+      return {
+        accountId,
+        profileHistoryDirectory: profileHistoryDir,
+        profileHistoryManifestPath: manifestPath,
+        processedCount,
+        downloadStats,
+        downloadResults,
+        totalResults: downloadResults.length,
+        guidance: this.buildDownloadGuidance(
+          'profile picture history images',
+          downloadStats
+        ),
       };
     } catch (error) {
       if (!this.isOperationCancelledError(error)) {
@@ -1506,6 +1837,155 @@ export class RecNetService extends EventEmitter {
         retries: Math.max(0, attemptsUsed - 1),
       };
     }
+  }
+
+  private async downloadProfileHistoryImage(
+    photo: Photo,
+    profileHistoryDir: string,
+    token: string,
+    operation?: CurrentOperation
+  ): Promise<DownloadResultItem> {
+    const photoId = this.sanitizeFileStem(this.normalizeId(photo.Id));
+    const imageName = photo.ImageName;
+    const photoUrl = buildCdnImageUrl(this.settings.cdnBase, imageName);
+
+    if (!photoId || !imageName) {
+      return {
+        error: 'invalid_profile_history_entry',
+        photoId,
+        imageName,
+        photo: JSON.stringify(photo),
+      };
+    }
+
+    if (operation?.cancelled || this.currentOperation?.cancelled) {
+      return {
+        photoId,
+        status: 'cancelled',
+      };
+    }
+
+    const photoPath = path.join(profileHistoryDir, `${photoId}.jpg`);
+    if (await fs.pathExists(photoPath)) {
+      return {
+        photoId,
+        status: 'already_exists_in_profile_history',
+        path: photoPath,
+      };
+    }
+
+    let attemptsUsed = 1;
+    try {
+      const attempt = await this.downloadPhotoWithRetry(
+        imageName,
+        token,
+        operation
+      );
+      attemptsUsed = attempt.attempts;
+      const response = attempt.response;
+      const recoveredAfterRetry =
+        attempt.attempts > 1 && !!response?.success && !!response.value;
+
+      if (response?.success && response.value) {
+        const data = Buffer.from(response.value);
+        await fs.writeFile(photoPath, data);
+        return {
+          photoId,
+          status: 'downloaded',
+          size: data.length,
+          path: photoPath,
+          url: photoUrl,
+          attempts: attempt.attempts,
+          retries: Math.max(0, attempt.attempts - 1),
+          recoveredAfterRetry,
+        };
+      }
+
+      if (response) {
+        return {
+          photoId,
+          status: 'failed',
+          statusCode: response.status,
+          reason: (response.message || response.error) ?? undefined,
+          url: photoUrl,
+          attempts: attempt.attempts,
+          retries: Math.max(0, attempt.attempts - 1),
+        };
+      }
+
+      throw attempt.error ?? new Error('Download failed after retries');
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Operation cancelled') {
+        return {
+          photoId,
+          status: 'cancelled',
+        };
+      }
+
+      return {
+        photoId,
+        status: 'error',
+        error: (error as Error).message,
+        url: photoUrl,
+        attempts: attemptsUsed,
+        retries: Math.max(0, attemptsUsed - 1),
+      };
+    }
+  }
+
+  private decodeJwtPayload(token: string): JwtPayload | null {
+    try {
+      const parts = token.trim().split('.');
+      if (parts.length !== 3) {
+        return null;
+      }
+
+      const payload = parts[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
+      const decoded = Buffer.from(payload, 'base64').toString('utf8');
+      return JSON.parse(decoded) as JwtPayload;
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeProfileHistoryPhotos(
+    payload: ProfileHistoryImageDto[],
+    accountId: string
+  ): Photo[] {
+    const normalizedAccountId = this.normalizeId(accountId);
+
+    return payload
+      .map<Photo>(photo => ({
+        ...photo,
+        Id: this.sanitizeFileStem(this.normalizeId(photo.Id)),
+        Description: photo.Description ?? '',
+        PlayerId: this.normalizeId(photo.PlayerId) || normalizedAccountId,
+        TaggedPlayerIds: Array.isArray(photo.TaggedPlayerIds)
+          ? photo.TaggedPlayerIds.map(id => this.normalizeId(id)).filter(Boolean)
+          : [],
+        RoomId: this.normalizeId(photo.RoomId),
+        PlayerEventId: this.normalizeId(photo.PlayerEventId) || undefined,
+      }))
+      .filter(photo => !!photo.Id && !!photo.ImageName)
+      .sort((a, b) => {
+        const timeA = a.CreatedAt
+          ? new Date(a.CreatedAt).getTime()
+          : Number.MAX_SAFE_INTEGER;
+        const timeB = b.CreatedAt
+          ? new Date(b.CreatedAt).getTime()
+          : Number.MAX_SAFE_INTEGER;
+        if (timeA !== timeB) {
+          return timeA - timeB;
+        }
+        return this.compareIds(a.Id, b.Id);
+      });
+  }
+
+  private sanitizeFileStem(value: string): string {
+    return value.trim().replace(/[<>:"/\\|?*\u0000-\u001f]/g, '_');
   }
 
   private normalizeId(value: unknown): string {
@@ -2369,9 +2849,15 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async lookupAccountByUsername(username: string): Promise<AccountInfo> {
+  async lookupAccountByUsername(
+    username: string,
+    token?: string
+  ): Promise<AccountInfo> {
     try {
-      return await this.accountsController.lookupAccountByUsername(username);
+      return await this.accountsController.lookupAccountByUsername(
+        username,
+        token
+      );
     } catch (error) {
       throw new Error(
         `Failed to lookup account by username: ${(error as Error).message}`
@@ -2412,6 +2898,7 @@ export class RecNetService extends EventEmitter {
             const metadataFiles = [
               `${entry.name}_photos.json`,
               `${entry.name}_feed.json`,
+              `${entry.name}_profile_history.json`,
               `${entry.name}_accounts.json`,
               `${entry.name}_rooms.json`,
               `${entry.name}_events.json`,
@@ -2431,7 +2918,9 @@ export class RecNetService extends EventEmitter {
             }
           } else if (entry.isFile()) {
             const isLegacyMetadata =
-              /.+_(photos|feed|accounts|rooms|events)\.json$/i.test(entry.name);
+              /.+_(photos|feed|profile_history|accounts|rooms|events)\.json$/i.test(
+                entry.name
+              );
             if (isLegacyMetadata) {
               await fs.remove(entryPath);
               removedLegacyFiles++;
@@ -2508,8 +2997,10 @@ export class RecNetService extends EventEmitter {
       accountId: string;
       hasPhotos: boolean;
       hasFeed: boolean;
+      hasProfileHistory: boolean;
       photoCount: number;
       feedCount: number;
+      profileHistoryCount: number;
       displayLabel?: string;
     }>
   > {
@@ -2518,8 +3009,10 @@ export class RecNetService extends EventEmitter {
       accountId: string;
       hasPhotos: boolean;
       hasFeed: boolean;
+      hasProfileHistory: boolean;
       photoCount: number;
       feedCount: number;
+      profileHistoryCount: number;
       displayLabel?: string;
     }> = [];
 
@@ -2546,6 +3039,10 @@ export class RecNetService extends EventEmitter {
           `${accountId}_photos.json`
         );
         const feedJsonPath = path.join(accountDir, `${accountId}_feed.json`);
+        const profileHistoryJsonPath = path.join(
+          accountDir,
+          `${accountId}_profile_history.json`
+        );
         const accountsJsonPath = path.join(
           accountDir,
           `${accountId}_accounts.json`
@@ -2553,8 +3050,10 @@ export class RecNetService extends EventEmitter {
 
         let hasPhotos = false;
         let hasFeed = false;
+        let hasProfileHistory = false;
         let photoCount = 0;
         let feedCount = 0;
+        let profileHistoryCount = 0;
         let displayLabel: string | undefined;
 
         // Check for photos metadata
@@ -2589,8 +3088,27 @@ export class RecNetService extends EventEmitter {
           }
         }
 
+        if (await fs.pathExists(profileHistoryJsonPath)) {
+          try {
+            const profileHistory: Photo[] = await fs.readJson(
+              profileHistoryJsonPath
+            );
+            if (
+              Array.isArray(profileHistory) &&
+              profileHistory.length > 0
+            ) {
+              hasProfileHistory = true;
+              profileHistoryCount = profileHistory.length;
+            }
+          } catch (error) {
+            console.log(
+              `Failed to read profile history JSON for ${accountId}: ${(error as Error).message}`
+            );
+          }
+        }
+
         // Only include accounts that have at least one metadata file
-        if (hasPhotos || hasFeed) {
+        if (hasPhotos || hasFeed || hasProfileHistory) {
           // Prefer small folder metadata for owner display.
           const meta = await this.readFolderMeta(accountDir);
           if (meta?.owner) {
@@ -2637,8 +3155,10 @@ export class RecNetService extends EventEmitter {
             accountId,
             hasPhotos,
             hasFeed,
+            hasProfileHistory,
             photoCount,
             feedCount,
+            profileHistoryCount,
             displayLabel,
           });
         }

--- a/src/main/services/recnet/photos-controller.ts
+++ b/src/main/services/recnet/photos-controller.ts
@@ -3,6 +3,7 @@ import {
   shouldIncludeTokenForCdnBase,
 } from '../../../shared/cdnUrl';
 import { ImageDto } from '../../models/ImageDto';
+import { ProfileHistoryImageDto } from '../../models/ProfileHistoryImageDto';
 import { GenericResponse } from '../../models/GenericResponse';
 import { RecNetHttpClient, RecNetRequestOptions } from './http-client';
 
@@ -40,6 +41,22 @@ export class PhotosController {
 
     return this.http.requestOrThrow<ImageDto[]>(
       { url, method: 'GET' },
+      token,
+      options
+    );
+  }
+
+  // I am suspicious of this endpoint. It returns old photos from 2018 but stops at Dec 2021.
+  // It should have more recent entries.
+  async fetchProfilePhotoHistory(
+    token: string,
+    options?: RecNetRequestOptions
+  ): Promise<ProfileHistoryImageDto[]> {
+    return this.http.requestOrThrow<ProfileHistoryImageDto[]>(
+      {
+        url: 'https://api.rec.net/api/images/v3/profile/all',
+        method: 'GET',
+      },
       token,
       options
     );

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,8 +12,13 @@ import {
   RecNetSettings,
   Progress,
   BulkDataRefreshOptions,
+  DownloadResult,
   UserFacingIncident,
 } from '../shared/types';
+import {
+  DownloadSourceSelection,
+  getSelectedDownloadSources,
+} from '../shared/download-sources';
 import { FavoritesProvider } from './contexts/FavoritesContext';
 import {
   createUserIncident,
@@ -30,6 +35,7 @@ interface DownloadRequestState {
   username: string;
   token: string;
   filePath: string;
+  downloadSources: DownloadSourceSelection;
   refreshOptions: BulkDataRefreshOptions;
 }
 
@@ -37,6 +43,7 @@ function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
     outputRoot: 'output',
     cdnBase: DEFAULT_CDN_BASE,
+    maxConcurrentDownloads: 30,
   });
 
   const [progress, setProgress] = useState<Progress>({
@@ -213,6 +220,48 @@ function App() {
     []
   );
 
+  const reportDownloadResult = useCallback(
+    (params: {
+      operation: string;
+      label: string;
+      result: DownloadResult;
+      directoryPath?: string;
+      directoryLabel?: string;
+      manifestPath?: string;
+    }) => {
+      const { directoryLabel, directoryPath, label, manifestPath, operation, result } =
+        params;
+      const stats = result.downloadStats;
+
+      addLog(
+        stats.failedDownloads > 0
+          ? `${label} complete with warnings: ${stats.newDownloads} new, ${stats.alreadyDownloaded} existing, ${stats.failedDownloads} missed after retries`
+          : `${label} complete: ${stats.newDownloads} new, ${stats.alreadyDownloaded} existing, ${stats.failedDownloads} failed`,
+        stats.failedDownloads > 0 ? 'warning' : 'success'
+      );
+
+      if (stats.retryAttempts > 0) {
+        addLog(
+          stats.failedDownloads > 0
+            ? `Retried ${label.toLowerCase()} ${stats.retryAttempts} time(s) across failed attempts. ${stats.recoveredAfterRetry} file(s) recovered automatically.`
+            : `Retried ${label.toLowerCase()} ${stats.retryAttempts} time(s) and recovered ${stats.recoveredAfterRetry} file(s) automatically.`,
+          stats.failedDownloads > 0 ? 'warning' : 'info'
+        );
+      }
+
+      if (directoryPath && directoryLabel) {
+        addLog(`${directoryLabel}: ${directoryPath}`, 'info');
+      }
+      if (manifestPath) {
+        addLog(`Profile history manifest saved to: ${manifestPath}`, 'info');
+      }
+
+      result.guidance?.forEach(message => addLog(message, 'warning'));
+      addResult(operation, result, 'success');
+    },
+    [addLog, addResult]
+  );
+
   const clearLogs = () => {
     setLogs([]);
     setResults([]);
@@ -278,9 +327,11 @@ function App() {
     username: string,
     token: string,
     filePath: string,
+    downloadSources: DownloadSourceSelection,
     refreshOptions: BulkDataRefreshOptions = {}
   ) => {
-    if (!username.trim() || !filePath.trim()) {
+    const selectedSources = getSelectedDownloadSources(downloadSources);
+    if (!username.trim() || !filePath.trim() || selectedSources.length === 0) {
       return;
     }
 
@@ -295,6 +346,7 @@ function App() {
       username,
       token,
       filePath,
+      downloadSources,
       refreshOptions: {
         forceAccountsRefresh,
         forceRoomsRefresh,
@@ -346,146 +398,160 @@ function App() {
           `Found account: ${account.displayName} (ID: ${accountId})`,
           'success'
         );
-        addLog(
-          forceAccountsRefresh
-            ? 'Forcing refresh of user data for this download'
-            : 'Using existing user data if present',
-          'info'
-        );
-        addLog(
-          forceRoomsRefresh
-            ? 'Forcing refresh of room data for this download'
-            : 'Using existing room data if present',
-          'info'
-        );
-        addLog(
-          forceEventsRefresh
-            ? 'Forcing refresh of event data for this download'
-            : 'Using existing event data if present',
-          'info'
-        );
-
-        // Step 1: Collect photos & feed metadata
-        addLog('Step 1: Collecting photos metadata...', 'info');
-        const collectPhotosResult = await window.electronAPI.collectPhotos({
-          accountId,
-          token: token.trim() || undefined,
-          forceAccountsRefresh,
-          forceRoomsRefresh,
-          forceEventsRefresh,
-        });
-
-        addLog('Step 1b: Collecting feed photos metadata...', 'info');
-        const collectFeedResult = await window.electronAPI.collectFeedPhotos({
-          accountId,
-          token: token.trim() || undefined,
-          incremental: true,
-          forceAccountsRefresh,
-          forceRoomsRefresh,
-          forceEventsRefresh,
-        });
-
-        if (!collectPhotosResult.success) {
-          throw new Error(
-            collectPhotosResult.error || 'Failed to collect photos'
-          );
-        }
-        if (!collectFeedResult.success) {
-          throw new Error(
-            collectFeedResult.error || 'Failed to collect feed photos'
-          );
-        }
-
-        const totalPhotos = collectPhotosResult.data?.totalPhotos || 0;
-        addLog(`Collected ${totalPhotos} photos metadata`, 'success');
-        const totalFeedPhotos = collectFeedResult.data?.totalPhotos || 0;
-        addLog(`Collected ${totalFeedPhotos} feed photos metadata`, 'success');
-
-        // Reload photos immediately after collection so they're visible
-        loadPhotosForAccount(accountId);
-
-        // Step 2: Download photos
-        addLog('Step 2: Downloading photos...', 'info');
-        const downloadResult = await window.electronAPI.downloadPhotos({
-          accountId,
-          token: token.trim() || undefined,
-        });
-
-        if (!downloadResult.success) {
-          throw new Error(downloadResult.error || 'Failed to download photos');
-        }
-
-        const downloadStats = downloadResult.data?.downloadStats;
-        if (downloadStats) {
+        if (
+          downloadSources.downloadUserFeed ||
+          downloadSources.downloadUserPhotos
+        ) {
           addLog(
-            downloadStats.failedDownloads > 0
-              ? `Download complete with warnings: ${downloadStats.newDownloads} new, ${downloadStats.alreadyDownloaded} existing, ${downloadStats.failedDownloads} missed after retries`
-              : `Download complete: ${downloadStats.newDownloads} new, ${downloadStats.alreadyDownloaded} existing, ${downloadStats.failedDownloads} failed`,
-            downloadStats.failedDownloads > 0 ? 'warning' : 'success'
+            forceAccountsRefresh
+              ? 'Forcing refresh of user data for this download'
+              : 'Using existing user data if present',
+            'info'
           );
-          if (downloadStats.retryAttempts > 0) {
-            addLog(
-              downloadStats.failedDownloads > 0
-                ? `Retried user photo downloads ${downloadStats.retryAttempts} time(s) across failed attempts. ${downloadStats.recoveredAfterRetry} photo(s) recovered automatically.`
-                : `Retried user photo downloads ${downloadStats.retryAttempts} time(s) and recovered ${downloadStats.recoveredAfterRetry} photo(s) automatically.`,
-              downloadStats.failedDownloads > 0 ? 'warning' : 'info'
-            );
-          }
-          if (downloadResult.data?.photosDirectory) {
-            addLog(
-              `User photos saved to: ${downloadResult.data.photosDirectory}`,
-              'info'
-            );
-          }
-          downloadResult.data?.guidance?.forEach(message =>
-            addLog(message, 'warning')
-          );
-          addResult('Download', downloadResult.data, 'success');
-        }
-
-        // Step 3: Download feed photos
-        addLog('Step 3: Downloading feed photos...', 'info');
-        const downloadFeedResult = await window.electronAPI.downloadFeedPhotos({
-          accountId,
-          token: token.trim() || undefined,
-        });
-
-        if (!downloadFeedResult.success) {
-          throw new Error(
-            downloadFeedResult.error || 'Failed to download feed photos'
-          );
-        }
-
-        const downloadFeedStats = downloadFeedResult.data?.downloadStats;
-        if (downloadFeedStats) {
           addLog(
-            downloadFeedStats.failedDownloads > 0
-              ? `Feed download complete with warnings: ${downloadFeedStats.newDownloads} new, ${downloadFeedStats.alreadyDownloaded} existing, ${downloadFeedStats.failedDownloads} missed after retries`
-              : `Feed download complete: ${downloadFeedStats.newDownloads} new, ${downloadFeedStats.alreadyDownloaded} existing, ${downloadFeedStats.failedDownloads} failed`,
-            downloadFeedStats.failedDownloads > 0 ? 'warning' : 'success'
+            forceRoomsRefresh
+              ? 'Forcing refresh of room data for this download'
+              : 'Using existing room data if present',
+            'info'
           );
-          if (downloadFeedStats.retryAttempts > 0) {
-            addLog(
-              downloadFeedStats.failedDownloads > 0
-                ? `Retried feed photo downloads ${downloadFeedStats.retryAttempts} time(s) across failed attempts. ${downloadFeedStats.recoveredAfterRetry} photo(s) recovered automatically.`
-                : `Retried feed photo downloads ${downloadFeedStats.retryAttempts} time(s) and recovered ${downloadFeedStats.recoveredAfterRetry} photo(s) automatically.`,
-              downloadFeedStats.failedDownloads > 0 ? 'warning' : 'info'
-            );
-          }
-          if (downloadFeedResult.data?.feedPhotosDirectory) {
-            addLog(
-              `Feed photos saved to: ${downloadFeedResult.data.feedPhotosDirectory}`,
-              'info'
-            );
-          }
-          downloadFeedResult.data?.guidance?.forEach(message =>
-            addLog(message, 'warning')
+          addLog(
+            forceEventsRefresh
+              ? 'Forcing refresh of event data for this download'
+              : 'Using existing event data if present',
+            'info'
           );
-          addResult('Feed Download', downloadFeedResult.data, 'success');
         }
 
-        // Reload photos after download completes
-        loadPhotosForAccount(accountId);
+        for (const source of selectedSources) {
+          if (source === 'user-feed') {
+            addLog('Collecting feed photos metadata...', 'info');
+            const collectFeedResult = await window.electronAPI.collectFeedPhotos({
+              accountId,
+              token: token.trim() || undefined,
+              incremental: true,
+              forceAccountsRefresh,
+              forceRoomsRefresh,
+              forceEventsRefresh,
+            });
+
+            if (!collectFeedResult.success) {
+              throw new Error(
+                collectFeedResult.error || 'Failed to collect feed photos'
+              );
+            }
+
+            const totalFeedPhotos = collectFeedResult.data?.totalPhotos || 0;
+            addLog(`Collected ${totalFeedPhotos} feed photos metadata`, 'success');
+
+            addLog('Downloading feed photos...', 'info');
+            const downloadFeedResult =
+              await window.electronAPI.downloadFeedPhotos({
+                accountId,
+                token: token.trim() || undefined,
+              });
+
+            if (!downloadFeedResult.success || !downloadFeedResult.data) {
+              throw new Error(
+                downloadFeedResult.error || 'Failed to download feed photos'
+              );
+            }
+
+            reportDownloadResult({
+              operation: 'User Feed Download',
+              label: 'Feed download',
+              result: downloadFeedResult.data,
+              directoryPath: downloadFeedResult.data.feedPhotosDirectory,
+              directoryLabel: 'Feed photos saved to',
+            });
+            loadPhotosForAccount(accountId);
+            continue;
+          }
+
+          if (source === 'user-photos') {
+            addLog('Collecting user photos metadata...', 'info');
+            const collectPhotosResult = await window.electronAPI.collectPhotos({
+              accountId,
+              token: token.trim() || undefined,
+              forceAccountsRefresh,
+              forceRoomsRefresh,
+              forceEventsRefresh,
+            });
+
+            if (!collectPhotosResult.success) {
+              throw new Error(
+                collectPhotosResult.error || 'Failed to collect photos'
+              );
+            }
+
+            const totalPhotos = collectPhotosResult.data?.totalPhotos || 0;
+            addLog(`Collected ${totalPhotos} photos metadata`, 'success');
+
+            addLog('Downloading user photos...', 'info');
+            const downloadPhotosResult = await window.electronAPI.downloadPhotos({
+              accountId,
+              token: token.trim() || undefined,
+            });
+
+            if (!downloadPhotosResult.success || !downloadPhotosResult.data) {
+              throw new Error(
+                downloadPhotosResult.error || 'Failed to download photos'
+              );
+            }
+
+            reportDownloadResult({
+              operation: 'User Photos Download',
+              label: 'User photos download',
+              result: downloadPhotosResult.data,
+              directoryPath: downloadPhotosResult.data.photosDirectory,
+              directoryLabel: 'User photos saved to',
+            });
+            loadPhotosForAccount(accountId);
+            continue;
+          }
+
+          if (source === 'profile-history') {
+            if (!token.trim()) {
+              throw new Error(
+                'Profile picture history requires a valid access token.'
+              );
+            }
+
+            addLog('Downloading profile picture history...', 'info');
+            const downloadProfileHistoryResult =
+              await window.electronAPI.downloadProfileHistory({
+                accountId,
+                token: token.trim(),
+              });
+
+            if (
+              !downloadProfileHistoryResult.success ||
+              !downloadProfileHistoryResult.data
+            ) {
+              throw new Error(
+                downloadProfileHistoryResult.error ||
+                  'Failed to download profile picture history'
+              );
+            }
+
+            reportDownloadResult({
+              operation: 'Profile Picture History Download',
+              label: 'Profile picture history download',
+              result: downloadProfileHistoryResult.data,
+              directoryPath:
+                downloadProfileHistoryResult.data.profileHistoryDirectory,
+              directoryLabel: 'Profile picture history saved to',
+              manifestPath:
+                downloadProfileHistoryResult.data.profileHistoryManifestPath,
+            });
+          }
+        }
+
+        if (
+          downloadSources.downloadUserFeed ||
+          downloadSources.downloadUserPhotos
+        ) {
+          loadPhotosForAccount(accountId);
+        }
         setActiveIncident(null);
       }
     } catch (error) {
@@ -561,6 +627,7 @@ function App() {
       retryRequest.username,
       retryRequest.token,
       retryRequest.filePath,
+      retryRequest.downloadSources,
       retryRequest.refreshOptions
     );
   }, [handleDownload, isDownloading, retryRequest]);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,6 +39,8 @@ interface DownloadRequestState {
   refreshOptions: BulkDataRefreshOptions;
 }
 
+const EMPTY_DOWNLOAD_STEP = 'Nothing to download';
+
 function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
     outputRoot: 'output',
@@ -372,6 +374,8 @@ function App() {
     });
 
     try {
+      let encounteredEmptySource = false;
+
       // Update settings with new file path
       if (window.electronAPI) {
         await window.electronAPI.updateSettings({ outputRoot: filePath });
@@ -441,6 +445,34 @@ function App() {
             }
 
             const totalFeedPhotos = collectFeedResult.data?.totalPhotos || 0;
+            if (totalFeedPhotos === 0) {
+              const emptyMessage =
+                'This account does not have any feed photos to download.';
+              addLog(emptyMessage, 'warning');
+              setShowProgressPanel(true);
+              setProgress(prev => ({
+                ...prev,
+                isRunning: false,
+                currentStep: EMPTY_DOWNLOAD_STEP,
+                progress: 100,
+                total: 0,
+                current: 0,
+                statusLevel: 'warning',
+                issueCount: 0,
+                retryAttempts: 0,
+                failedItems: 0,
+                recoveredAfterRetry: 0,
+                lastIssue: emptyMessage,
+              }));
+              setActiveIncident(
+                createUserIncident('download', emptyMessage, {
+                  severity: 'warning',
+                })
+              );
+              encounteredEmptySource = true;
+              continue;
+            }
+
             addLog(`Collected ${totalFeedPhotos} feed photos metadata`, 'success');
 
             addLog('Downloading feed photos...', 'info');
@@ -484,6 +516,34 @@ function App() {
             }
 
             const totalPhotos = collectPhotosResult.data?.totalPhotos || 0;
+            if (totalPhotos === 0) {
+              const emptyMessage =
+                'This account does not have any user photos to download.';
+              addLog(emptyMessage, 'warning');
+              setShowProgressPanel(true);
+              setProgress(prev => ({
+                ...prev,
+                isRunning: false,
+                currentStep: EMPTY_DOWNLOAD_STEP,
+                progress: 100,
+                total: 0,
+                current: 0,
+                statusLevel: 'warning',
+                issueCount: 0,
+                retryAttempts: 0,
+                failedItems: 0,
+                recoveredAfterRetry: 0,
+                lastIssue: emptyMessage,
+              }));
+              setActiveIncident(
+                createUserIncident('download', emptyMessage, {
+                  severity: 'warning',
+                })
+              );
+              encounteredEmptySource = true;
+              continue;
+            }
+
             addLog(`Collected ${totalPhotos} photos metadata`, 'success');
 
             addLog('Downloading user photos...', 'info');
@@ -552,11 +612,14 @@ function App() {
         ) {
           loadPhotosForAccount(accountId);
         }
-        setActiveIncident(null);
+        if (!encounteredEmptySource) {
+          setActiveIncident(null);
+        }
       }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Download failed';
+      const classifiedError = classifyError(errorMessage, 'download');
 
       if (errorMessage === 'Operation cancelled') {
         addLog('Download cancelled by user.', 'warning');
@@ -574,9 +637,27 @@ function App() {
         setActiveIncident(
           createUserIncident('download', errorMessage, { severity: 'warning' })
         );
+      } else if (classifiedError.category === 'empty') {
+        addLog(classifiedError.detail, 'warning');
+        setShowProgressPanel(true);
+        setProgress(prev => ({
+          ...prev,
+          isRunning: false,
+          currentStep: EMPTY_DOWNLOAD_STEP,
+          progress: 100,
+          total: 0,
+          current: 0,
+          statusLevel: 'warning',
+          issueCount: 0,
+          failedItems: 0,
+          lastIssue: classifiedError.detail,
+        }));
+        setActiveIncident(
+          createUserIncident('download', errorMessage, { severity: 'warning' })
+        );
       } else {
         addLog(`Download failed: ${errorMessage}`, 'error');
-        classifyError(errorMessage, 'download').guidance.forEach(message =>
+        classifiedError.guidance.forEach(message =>
           addLog(message, 'warning')
         );
         setShowProgressPanel(true);
@@ -609,6 +690,8 @@ function App() {
             ? 'Cancelled'
             : prev.currentStep === 'Failed'
               ? 'Failed'
+              : prev.currentStep === EMPTY_DOWNLOAD_STEP
+                ? EMPTY_DOWNLOAD_STEP
               : 'Complete',
         progress:
           prev.currentStep === 'Cancelled' ? prev.progress : 100,

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
+  ChevronDown,
+  ChevronRight,
   Download,
   FolderOpen,
-  Key,
   HelpCircle,
-  X,
+  Key,
   RefreshCcw,
+  X,
 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -18,6 +20,29 @@ import {
   DialogTitle,
 } from '../components/ui/dialog';
 import { RecNetSettings } from '../../shared/types';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../components/ui/tooltip';
+import {
+  DEFAULT_DOWNLOAD_SOURCE_SELECTION,
+  DownloadSourceSelection,
+  hasSelectedDownloadSources,
+} from '../../shared/download-sources';
+
+interface DownloadDraft {
+  username: string;
+  token: string;
+  filePath: string;
+  downloadSources: DownloadSourceSelection;
+  refreshOptions: {
+    forceAccountsRefresh: boolean;
+    forceRoomsRefresh: boolean;
+    forceEventsRefresh: boolean;
+  };
+}
 
 interface DownloadPanelProps {
   open: boolean;
@@ -26,26 +51,21 @@ interface DownloadPanelProps {
     username: string,
     token: string,
     filePath: string,
+    downloadSources: DownloadSourceSelection,
     refreshOptions: {
       forceAccountsRefresh: boolean;
       forceRoomsRefresh: boolean;
       forceEventsRefresh: boolean;
     }
   ) => Promise<void>;
-  onDraftChange?: (draft: {
-    username: string;
-    token: string;
-    filePath: string;
-    refreshOptions: {
-      forceAccountsRefresh: boolean;
-      forceRoomsRefresh: boolean;
-      forceEventsRefresh: boolean;
-    };
-  }) => void;
+  onDraftChange?: (draft: DownloadDraft) => void;
   onCancel?: () => void;
   isDownloading?: boolean;
   settings: RecNetSettings;
 }
+
+type UsernameStatus = 'idle' | 'checking' | 'found' | 'not-found';
+type TokenStatus = 'idle' | 'checking' | 'parsed' | 'verified' | 'invalid';
 
 export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   open,
@@ -60,44 +80,47 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   const [username, setUsername] = useState('');
   const [token, setToken] = useState('');
   const [filePath, setFilePath] = useState(settings.outputRoot || '');
-  const [usernameStatus, setUsernameStatus] = useState<
-    'idle' | 'checking' | 'found' | 'not-found'
-  >('idle');
-  const [tokenStatus, setTokenStatus] = useState<
-    'idle' | 'checking' | 'valid' | 'invalid'
-  >('idle');
+  const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>('idle');
+  const [tokenStatus, setTokenStatus] = useState<TokenStatus>('idle');
+  const [tokenStatusMessage, setTokenStatusMessage] = useState(
+    'Optional. Required for profile picture history and private-image access.'
+  );
   const [tokenExpiringSoon, setTokenExpiringSoon] = useState(false);
   const [tokenHelpOpen, setTokenHelpOpen] = useState(false);
-  const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(
-    null
+  const [downloadSources, setDownloadSources] = useState<DownloadSourceSelection>(
+    DEFAULT_DOWNLOAD_SOURCE_SELECTION
   );
-  const [tokenTimeout, setTokenTimeout] = useState<NodeJS.Timeout | null>(null);
   const [forceAccountsRefresh, setForceAccountsRefresh] = useState(false);
   const [forceRoomsRefresh, setForceRoomsRefresh] = useState(false);
   const [forceEventsRefresh, setForceEventsRefresh] = useState(false);
   const [folderError, setFolderError] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const tokenValidationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const tokenValidationRequestIdRef = useRef(0);
 
   useEffect(() => {
     setFilePath(settings.outputRoot || '');
   }, [settings.outputRoot]);
 
   useEffect(() => {
-    // Cleanup timeout on unmount
     return () => {
-      if (searchTimeout) {
-        clearTimeout(searchTimeout);
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
       }
-      if (tokenTimeout) {
-        clearTimeout(tokenTimeout);
+      if (tokenValidationTimeoutRef.current) {
+        clearTimeout(tokenValidationTimeoutRef.current);
       }
     };
-  }, [searchTimeout, tokenTimeout]);
+  }, []);
 
   useEffect(() => {
     if (open) {
       setForceAccountsRefresh(false);
       setForceRoomsRefresh(false);
       setForceEventsRefresh(false);
+      setAdvancedOpen(false);
     }
   }, [open]);
 
@@ -106,6 +129,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       username,
       token,
       filePath,
+      downloadSources,
       refreshOptions: {
         forceAccountsRefresh,
         forceRoomsRefresh,
@@ -113,6 +137,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       },
     });
   }, [
+    downloadSources,
     filePath,
     forceAccountsRefresh,
     forceEventsRefresh,
@@ -121,6 +146,20 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     token,
     username,
   ]);
+
+  const clearSearchTimeout = () => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+      searchTimeoutRef.current = null;
+    }
+  };
+
+  const clearTokenValidationTimeout = () => {
+    if (tokenValidationTimeoutRef.current) {
+      clearTimeout(tokenValidationTimeoutRef.current);
+      tokenValidationTimeoutRef.current = null;
+    }
+  };
 
   const checkUsername = async (value: string) => {
     if (!value.trim()) {
@@ -141,40 +180,40 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
           setUsernameStatus('not-found');
         }
       }
-    } catch (error) {
+    } catch {
       setUsernameStatus('not-found');
     }
   };
 
   const cleanToken = (tokenValue: string): string => {
-    // Remove "Bearer " prefix if present (case insensitive)
     let cleaned = tokenValue.trim();
     if (cleaned.toLowerCase().startsWith('bearer ')) {
       cleaned = cleaned.substring(7).trim();
     }
-    // Remove any extra spaces
-    cleaned = cleaned.replace(/\s+/g, '');
-    return cleaned;
+    return cleaned.replace(/\s+/g, '');
   };
 
-  const decodeJWT = (token: string): { sub?: string; exp?: number } | null => {
+  const decodeJWT = (tokenValue: string): { sub?: string; exp?: number } | null => {
     try {
-      // JWT tokens have three parts: header.payload.signature
-      const parts = token.split('.');
+      const parts = tokenValue.split('.');
       if (parts.length !== 3) {
         return null;
       }
 
-      // Decode the payload (second part)
       const payload = parts[1];
-      // Base64URL decode
       const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
       const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-      const decoded = atob(padded);
-      return JSON.parse(decoded);
-    } catch (error) {
+      return JSON.parse(atob(padded));
+    } catch {
       return null;
     }
+  };
+
+  const isTokenExpired = (decoded: { exp?: number }): boolean => {
+    if (!decoded.exp) {
+      return false;
+    }
+    return decoded.exp * 1000 <= Date.now();
   };
 
   const checkTokenExpiration = (decoded: { exp?: number }): boolean => {
@@ -182,70 +221,69 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
       return false;
     }
 
-    // exp is in seconds since Unix epoch
-    const expirationTime = decoded.exp * 1000; // Convert to milliseconds
+    const expirationTime = decoded.exp * 1000;
     const currentTime = Date.now();
     const timeUntilExpiration = expirationTime - currentTime;
-    const twentyMinutesInMs = 20 * 60 * 1000; // 20 minutes in milliseconds
-
-    // Return true if token expires in 20 minutes or less (and hasn't already expired)
+    const twentyMinutesInMs = 20 * 60 * 1000;
     return timeUntilExpiration <= twentyMinutesInMs && timeUntilExpiration > 0;
   };
 
-  const validateToken = (tokenValue: string) => {
-    if (!tokenValue.trim()) {
-      setTokenStatus('idle');
-      setTokenExpiringSoon(false);
-      return;
-    }
-
-    setTokenStatus('checking');
-    setTokenExpiringSoon(false);
-
+  const validateProfileHistoryAccess = async (
+    usernameValue: string,
+    tokenValue: string,
+    requestId: number
+  ) => {
     try {
-      // Clean the token
-      const cleaned = cleanToken(tokenValue);
+      if (!electronAPI?.validateProfileHistoryAccess) {
+        throw new Error('Profile history validation is unavailable.');
+      }
 
-      // Decode the JWT (no ownership/account checks)
-      const decoded = decodeJWT(cleaned);
+      const result = await electronAPI.validateProfileHistoryAccess({
+        username: usernameValue,
+        token: tokenValue,
+      });
 
-      if (!decoded) {
-        setTokenStatus('invalid');
-        setTokenExpiringSoon(false);
+      if (requestId !== tokenValidationRequestIdRef.current) {
         return;
       }
 
-      // Check if token is expiring soon
-      const isExpiringSoon = checkTokenExpiration(decoded);
-      setTokenExpiringSoon(isExpiringSoon);
-      setTokenStatus('valid');
+      if (result.success && result.data) {
+        setTokenStatus('verified');
+        setTokenStatusMessage(
+          `Profile picture history is available for @${result.data.username}.`
+        );
+      } else {
+        setTokenStatus('invalid');
+        setTokenStatusMessage(
+          result.error || 'Token does not belong to this user.'
+        );
+      }
     } catch (error) {
+      if (requestId !== tokenValidationRequestIdRef.current) {
+        return;
+      }
       setTokenStatus('invalid');
-      setTokenExpiringSoon(false);
+      setTokenStatusMessage(
+        error instanceof Error
+          ? error.message
+          : 'Could not validate profile picture history access.'
+      );
     }
   };
 
   const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setUsername(value);
+    clearSearchTimeout();
 
-    // Clear existing timeout
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
-
-    // Reset status if empty
     if (!value.trim()) {
       setUsernameStatus('idle');
       return;
     }
 
-    // Debounce the search
-    const timeout = setTimeout(() => {
-      checkUsername(value);
+    searchTimeoutRef.current = setTimeout(() => {
+      void checkUsername(value);
     }, 1000);
-
-    setSearchTimeout(timeout);
   };
 
   const handleSelectFolder = async () => {
@@ -257,7 +295,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
           setFilePath(selectedPath);
         }
       }
-    } catch (error) {
+    } catch {
       setFolderError(
         'Could not open folder picker. Try typing the path manually.'
       );
@@ -265,106 +303,189 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   };
 
   const handleTokenChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
+    setToken(cleanToken(e.target.value));
+  };
 
-    // Clean the token immediately
-    const cleaned = cleanToken(value);
-
-    // Update state with cleaned value
-    setToken(cleaned);
-
-    // Clear existing timeout
-    if (tokenTimeout) {
-      clearTimeout(tokenTimeout);
-    }
-
-    // Reset status if empty
-    if (!cleaned.trim()) {
-      setTokenStatus('idle');
+  useEffect(() => {
+    if (!username.trim()) {
       return;
     }
 
-    // Debounce the validation
-    const timeout = setTimeout(() => {
-      validateToken(cleaned);
-    }, 500);
-
-    setTokenTimeout(timeout);
-  };
-
-  // Re-check username existence when token changes, so optional auth
-  // is used for account lookup.
-  useEffect(() => {
-    if (!username.trim()) return;
-
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
-
-    const timeout = setTimeout(() => {
+    clearSearchTimeout();
+    searchTimeoutRef.current = setTimeout(() => {
       void checkUsername(username);
     }, 1000);
 
-    setSearchTimeout(timeout);
-
+    return () => clearSearchTimeout();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
+
+  useEffect(() => {
+    clearTokenValidationTimeout();
+    tokenValidationRequestIdRef.current += 1;
+
+    const cleanedToken = cleanToken(token);
+    if (!cleanedToken) {
+      setTokenStatus('idle');
+      setTokenStatusMessage(
+        'Optional. Required for profile picture history and private-image access.'
+      );
+      setTokenExpiringSoon(false);
+      return;
+    }
+
+    const decoded = decodeJWT(cleanedToken);
+    if (!decoded) {
+      setTokenStatus('invalid');
+      setTokenStatusMessage('Token is invalid or could not be parsed.');
+      setTokenExpiringSoon(false);
+      return;
+    }
+
+    if (isTokenExpired(decoded)) {
+      setTokenStatus('invalid');
+      setTokenStatusMessage('Token has expired.');
+      setTokenExpiringSoon(false);
+      return;
+    }
+
+    setTokenExpiringSoon(checkTokenExpiration(decoded));
+
+    if (!username.trim()) {
+      setTokenStatus('parsed');
+      setTokenStatusMessage(
+        'Token looks valid. Enter a username to verify profile picture history access.'
+      );
+      return;
+    }
+
+    const requestId = tokenValidationRequestIdRef.current;
+    setTokenStatus('checking');
+    setTokenStatusMessage(`Verifying token for @${username.trim()}...`);
+    tokenValidationTimeoutRef.current = setTimeout(() => {
+      void validateProfileHistoryAccess(username.trim(), cleanedToken, requestId);
+    }, 500);
+
+    return () => clearTokenValidationTimeout();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, username]);
+
+  useEffect(() => {
+    if (!downloadSources.downloadProfileHistory) {
+      return;
+    }
+    if (tokenStatus === 'verified') {
+      return;
+    }
+
+    setDownloadSources(current => ({
+      ...current,
+      downloadProfileHistory: false,
+    }));
+  }, [downloadSources.downloadProfileHistory, tokenStatus]);
+
+  const toggleDownloadSource = (
+    key: keyof DownloadSourceSelection,
+    checked: boolean
+  ) => {
+    setDownloadSources(current => ({
+      ...current,
+      [key]: checked,
+    }));
+  };
 
   const handleDownload = async () => {
     if (!username.trim() || !filePath.trim()) {
       return;
     }
-    // Clean the token before passing it
+    if (!hasSelectedDownloadSources(downloadSources)) {
+      return;
+    }
+
     const cleanedToken = cleanToken(token);
-    // Close the dialog before starting download
     onOpenChange(false);
-    await onDownload(username, cleanedToken, filePath, {
-      forceAccountsRefresh,
-      forceRoomsRefresh,
-      forceEventsRefresh,
-    });
+    await onDownload(
+      username,
+      cleanedToken,
+      filePath,
+      downloadSources,
+      {
+        forceAccountsRefresh,
+        forceRoomsRefresh,
+        forceEventsRefresh,
+      }
+    );
   };
 
-  const isFormValid = username.trim() !== '' && filePath.trim() !== '';
+  const isFormValid =
+    username.trim() !== '' &&
+    filePath.trim() !== '' &&
+    hasSelectedDownloadSources(downloadSources);
+  const profileHistoryEnabled = tokenStatus === 'verified';
+
+  const renderDownloadType = (params: {
+    id: string;
+    title: string;
+    description: string;
+    checked: boolean;
+    disabled?: boolean;
+    onChange: (checked: boolean) => void;
+    disabledReason?: string;
+  }) => {
+    const option = (
+      <label
+        htmlFor={params.id}
+        className={`flex items-start gap-3 rounded-md border p-3 transition-colors ${
+          params.checked ? 'border-primary bg-muted/40' : 'border-border'
+        } ${params.disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+      >
+        <input
+          id={params.id}
+          type="checkbox"
+          className="mt-1 h-4 w-4 rounded border-input"
+          checked={params.checked}
+          disabled={params.disabled}
+          onChange={event => params.onChange(event.target.checked)}
+        />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{params.title}</p>
+          <p className="text-sm text-muted-foreground">{params.description}</p>
+        </div>
+      </label>
+    );
+
+    if (params.disabled && params.disabledReason) {
+      return (
+        <TooltipProvider delayDuration={150}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="block">{option}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{params.disabledReason}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    }
+
+    return option;
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100%-2rem)] max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto">
+      <DialogContent className="w-[calc(100%-2rem)] max-w-3xl max-h-[calc(100dvh-2rem)] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Download className="h-5 w-5" />
             Download Photos
           </DialogTitle>
           <DialogDescription>
-            Enter your credentials and file path to download photos
+            Enter a token, username, save path, and choose what data to download.
           </DialogDescription>
         </DialogHeader>
+
         <div className="space-y-4">
-          <div className="rounded-md border bg-muted/40 p-3">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Download Flow
-            </p>
-            <ol className="mt-2 grid gap-2 text-sm sm:grid-cols-3">
-              <li className="flex items-center gap-2">
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-semibold">
-                  1
-                </span>
-                <span>Search @username</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-semibold">
-                  2
-                </span>
-                <span>Pick save folder</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-semibold">
-                  3
-                </span>
-                <span>Download photos</span>
-              </li>
-            </ol>
-          </div>
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Label htmlFor="token" className="flex items-center gap-2">
@@ -390,31 +511,23 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               className="flex min-h-[2.5rem] max-h-[6rem] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-y overflow-y-auto"
               rows={4}
             />
-            {tokenStatus === 'valid' && (
-              <p className="text-sm text-green-600 dark:text-green-400">
-                Token validated successfully
-              </p>
-            )}
-            {tokenStatus === 'invalid' && (
-              <p className="text-sm text-red-600 dark:text-red-400">
-                Token is invalid or could not be parsed
-              </p>
-            )}
-            {tokenStatus === 'checking' && (
-              <p className="text-sm text-muted-foreground">
-                Validating token...
-              </p>
-            )}
-            {tokenStatus === 'idle' && (
-              <p className="text-sm text-muted-foreground">
-                Optional - required if you want to download private photos as well
-                as public ones
-              </p>
-            )}
+            <p
+              className={`text-sm ${
+                tokenStatus === 'invalid'
+                  ? 'text-red-600 dark:text-red-400'
+                  : tokenStatus === 'verified'
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              {tokenStatus === 'checking'
+                ? 'Verifying token...'
+                : tokenStatusMessage}
+            </p>
             {tokenExpiringSoon && (
               <p className="text-sm text-red-600 dark:text-red-400">
-                Warning: Your token is expiring in 20 minutes or less. Please
-                get a fresh token (tokens last 1 hour).
+                Warning: Your token is expiring in 20 minutes or less. Please get
+                a fresh token.
               </p>
             )}
           </div>
@@ -429,12 +542,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             />
             {usernameStatus === 'found' && (
               <p className="text-sm text-green-600 dark:text-green-400">
-                Username found successfully
+                Username found successfully.
               </p>
             )}
             {usernameStatus === 'not-found' && (
               <p className="text-sm text-red-600 dark:text-red-400">
-                Username not found
+                Username not found.
               </p>
             )}
             {usernameStatus === 'checking' && (
@@ -466,9 +579,10 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Downloads are organized as{' '}
-              <code className="font-mono">[folder]/[accountId]/photos</code> and{' '}
-              <code className="font-mono">[folder]/[accountId]/feed</code>.
+              User photos save to <code className="font-mono">[folder]/[accountId]/photos</code>,
+              feed photos save to <code className="font-mono">[folder]/[accountId]/feed</code>,
+              and profile history saves to{' '}
+              <code className="font-mono">[folder]/[accountId]/profile-history</code>.
             </p>
           </div>
 
@@ -479,54 +593,111 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
           )}
 
           <div className="space-y-2">
-            <Label>Metadata Refresh</Label>
-            <p className="text-sm text-muted-foreground">
-              User, room, and event details are reused when available. Toggle
-              below to force a fresh download.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <Button
-                type="button"
-                variant={forceAccountsRefresh ? 'destructive' : 'outline'}
-                onClick={() => setForceAccountsRefresh(value => !value)}
-                disabled={isDownloading}
-                className="justify-start"
-              >
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                {forceAccountsRefresh
-                  ? 'Force user data refresh'
-                  : 'Use cached user data'}
-              </Button>
-              <Button
-                type="button"
-                variant={forceRoomsRefresh ? 'destructive' : 'outline'}
-                onClick={() => setForceRoomsRefresh(value => !value)}
-                disabled={isDownloading}
-                className="justify-start"
-              >
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                {forceRoomsRefresh
-                  ? 'Force room data refresh'
-                  : 'Use cached room data'}
-              </Button>
-              <Button
-                type="button"
-                variant={forceEventsRefresh ? 'destructive' : 'outline'}
-                onClick={() => setForceEventsRefresh(value => !value)}
-                disabled={isDownloading}
-                className="justify-start"
-              >
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                {forceEventsRefresh
-                  ? 'Force event data refresh'
-                  : 'Use cached event data'}
-              </Button>
+            <Label>Download Types</Label>
+            <div className="space-y-2">
+              {renderDownloadType({
+                id: 'download-user-feed',
+                title: 'User Feed',
+                description: 'Download photos the user was tagged in.',
+                checked: downloadSources.downloadUserFeed,
+                onChange: checked =>
+                  toggleDownloadSource('downloadUserFeed', checked),
+              })}
+              {renderDownloadType({
+                id: 'download-user-photos',
+                title: 'User Photos',
+                description: 'Download photos the user took.',
+                checked: downloadSources.downloadUserPhotos,
+                onChange: checked =>
+                  toggleDownloadSource('downloadUserPhotos', checked),
+              })}
+              {renderDownloadType({
+                id: 'download-profile-history',
+                title: 'Profile Picture History',
+                description:
+                  'Download the user profile picture history and save the raw JSON manifest.',
+                checked: downloadSources.downloadProfileHistory,
+                disabled: !profileHistoryEnabled,
+                disabledReason:
+                  tokenStatus === 'checking'
+                    ? 'Verifying the bearer token for this username.'
+                    : tokenStatusMessage,
+                onChange: checked =>
+                  toggleDownloadSource('downloadProfileHistory', checked),
+              })}
             </div>
+          </div>
+
+          <div className="rounded-md border">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-3 text-left"
+              onClick={() => setAdvancedOpen(value => !value)}
+            >
+              <div>
+                <p className="text-sm font-medium">Advanced</p>
+                <p className="text-sm text-muted-foreground">
+                  Cache refresh options for feed and photo collection.
+                </p>
+              </div>
+              {advancedOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </button>
+            {advancedOpen && (
+              <div className="border-t px-3 pb-3 pt-2 space-y-2">
+                <p className="text-sm text-muted-foreground">
+                  User, room, and event details are reused when available. Toggle
+                  below to force a fresh download.
+                </p>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <Button
+                    type="button"
+                    variant={forceAccountsRefresh ? 'destructive' : 'outline'}
+                    onClick={() => setForceAccountsRefresh(value => !value)}
+                    disabled={isDownloading}
+                    className="justify-start"
+                  >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    {forceAccountsRefresh
+                      ? 'Force user data refresh'
+                      : 'Use cached user data'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={forceRoomsRefresh ? 'destructive' : 'outline'}
+                    onClick={() => setForceRoomsRefresh(value => !value)}
+                    disabled={isDownloading}
+                    className="justify-start"
+                  >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    {forceRoomsRefresh
+                      ? 'Force room data refresh'
+                      : 'Use cached room data'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={forceEventsRefresh ? 'destructive' : 'outline'}
+                    onClick={() => setForceEventsRefresh(value => !value)}
+                    disabled={isDownloading}
+                    className="justify-start"
+                  >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    {forceEventsRefresh
+                      ? 'Force event data refresh'
+                      : 'Use cached event data'}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
 
           {!isFormValid && (
             <p className="text-sm text-muted-foreground">
-              Enter your username and save folder to start.
+              Enter a username, choose a save folder, and select at least one
+              download type to start.
             </p>
           )}
 
@@ -553,45 +724,32 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
         </div>
       </DialogContent>
 
-      {/* Token Help Dialog */}
       <Dialog open={tokenHelpOpen} onOpenChange={setTokenHelpOpen}>
-        <DialogContent className="w-[calc(100%-2rem)] max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto">
+        <DialogContent className="w-[calc(100%-2rem)] max-w-2xl max-h-[calc(100dvh-2rem)] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>How to Get Your Token</DialogTitle>
             <DialogDescription>
-              Instructions for obtaining your RecNet access token
+              Instructions for obtaining your RecNet access token.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
               <p className="text-sm">
-                To download private photos, you need to obtain an access token
-                from RecNet:
+                To download private photos or profile picture history, obtain an
+                access token from RecNet:
               </p>
               <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
-                <li>Log in to your RecNet account in a web browser</li>
-                <li>
-                  Open your browser&apos;s Developer Tools (F12 or right-click →
-                  Inspect)
-                </li>
-                <li>Go to the Network tab</li>
-                <li>
-                  Navigate to any page on RecNet that requires authentication
-                </li>
-                <li>Look for requests to the RecNet API</li>
-                <li>Find the Authorization header in the request headers</li>
-                <li>
-                  Copy the token value (it usually starts with &quot;Bearer
-                  &quot;)
-                </li>
-                <li>
-                  Paste the token (without &quot;Bearer &quot;) into the token
-                  field above
-                </li>
+                <li>Log in to your RecNet account in a web browser.</li>
+                <li>Open your browser&apos;s Developer Tools and go to Network.</li>
+                <li>Navigate to any RecNet page that requires authentication.</li>
+                <li>Open one of the RecNet API requests.</li>
+                <li>Find the `Authorization` header in the request headers.</li>
+                <li>Copy the token value, usually after `Bearer `.</li>
+                <li>Paste the token into the field above.</li>
               </ol>
               <p className="text-sm text-muted-foreground mt-4">
-                <strong>Note:</strong> Tokens may expire after some time. If
-                downloads fail, you may need to obtain a new token.
+                <strong>Note:</strong> Tokens expire. If validation or downloads
+                start failing, obtain a fresh token.
               </p>
             </div>
           </div>

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -7,6 +7,7 @@ import {
   HelpCircle,
   Key,
   RefreshCcw,
+  UserRound,
   X,
 } from 'lucide-react';
 import { Button } from '../components/ui/button';
@@ -19,7 +20,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
-import { RecNetSettings } from '../../shared/types';
+import { buildCdnImageUrl } from '../../shared/cdnUrl';
+import { AccountInfo, RecNetSettings } from '../../shared/types';
+import { Card } from '../components/ui/card';
 import {
   Tooltip,
   TooltipContent,
@@ -81,15 +84,17 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   const [token, setToken] = useState('');
   const [filePath, setFilePath] = useState(settings.outputRoot || '');
   const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>('idle');
+  const [resolvedAccount, setResolvedAccount] = useState<AccountInfo | null>(
+    null
+  );
   const [tokenStatus, setTokenStatus] = useState<TokenStatus>('idle');
   const [tokenStatusMessage, setTokenStatusMessage] = useState(
-    'Optional. Required for profile picture history and private-image access.'
+    'Optional. Required for profile picture history and private image downloads.'
   );
   const [tokenExpiringSoon, setTokenExpiringSoon] = useState(false);
   const [tokenHelpOpen, setTokenHelpOpen] = useState(false);
-  const [downloadSources, setDownloadSources] = useState<DownloadSourceSelection>(
-    DEFAULT_DOWNLOAD_SOURCE_SELECTION
-  );
+  const [downloadSources, setDownloadSources] =
+    useState<DownloadSourceSelection>(DEFAULT_DOWNLOAD_SOURCE_SELECTION);
   const [forceAccountsRefresh, setForceAccountsRefresh] = useState(false);
   const [forceRoomsRefresh, setForceRoomsRefresh] = useState(false);
   const [forceEventsRefresh, setForceEventsRefresh] = useState(false);
@@ -99,6 +104,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const tokenValidationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const tokenValidationRequestIdRef = useRef(0);
+  const tokenTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     setFilePath(settings.outputRoot || '');
@@ -164,10 +170,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   const checkUsername = async (value: string) => {
     if (!value.trim()) {
       setUsernameStatus('idle');
+      setResolvedAccount(null);
       return;
     }
 
     setUsernameStatus('checking');
+    setResolvedAccount(null);
     try {
       if (electronAPI) {
         const result = await electronAPI.lookupAccountByUsername(
@@ -176,12 +184,15 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
         );
         if (result.success && result.data) {
           setUsernameStatus('found');
+          setResolvedAccount(result.data);
         } else {
           setUsernameStatus('not-found');
+          setResolvedAccount(null);
         }
       }
     } catch {
       setUsernameStatus('not-found');
+      setResolvedAccount(null);
     }
   };
 
@@ -193,7 +204,9 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     return cleaned.replace(/\s+/g, '');
   };
 
-  const decodeJWT = (tokenValue: string): { sub?: string; exp?: number } | null => {
+  const decodeJWT = (
+    tokenValue: string
+  ): { sub?: string; exp?: number } | null => {
     try {
       const parts = tokenValue.split('.');
       if (parts.length !== 3) {
@@ -278,6 +291,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
 
     if (!value.trim()) {
       setUsernameStatus('idle');
+      setResolvedAccount(null);
       return;
     }
 
@@ -306,6 +320,29 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     setToken(cleanToken(e.target.value));
   };
 
+  const handlePasteToken = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      const el = tokenTextareaRef.current;
+      if (el) {
+        const start = el.selectionStart ?? 0;
+        const end = el.selectionEnd ?? 0;
+        const combined = token.slice(0, start) + text + token.slice(end);
+        const next = cleanToken(combined);
+        setToken(next);
+        requestAnimationFrame(() => {
+          el.focus();
+          el.setSelectionRange(next.length, next.length);
+        });
+      } else {
+        setToken(cleanToken(token + text));
+      }
+    } catch {
+      // Clipboard API unavailable or denied
+      console.error('Clipboard API unavailable or denied');
+    }
+  };
+
   useEffect(() => {
     if (!username.trim()) {
       return;
@@ -328,7 +365,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     if (!cleanedToken) {
       setTokenStatus('idle');
       setTokenStatusMessage(
-        'Optional. Required for profile picture history and private-image access.'
+        'A bearer token is required for profile picture history and private image downloads.'
       );
       setTokenExpiringSoon(false);
       return;
@@ -363,7 +400,11 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     setTokenStatus('checking');
     setTokenStatusMessage(`Verifying token for @${username.trim()}...`);
     tokenValidationTimeoutRef.current = setTimeout(() => {
-      void validateProfileHistoryAccess(username.trim(), cleanedToken, requestId);
+      void validateProfileHistoryAccess(
+        username.trim(),
+        cleanedToken,
+        requestId
+      );
     }, 500);
 
     return () => clearTokenValidationTimeout();
@@ -404,17 +445,11 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
 
     const cleanedToken = cleanToken(token);
     onOpenChange(false);
-    await onDownload(
-      username,
-      cleanedToken,
-      filePath,
-      downloadSources,
-      {
-        forceAccountsRefresh,
-        forceRoomsRefresh,
-        forceEventsRefresh,
-      }
-    );
+    await onDownload(username, cleanedToken, filePath, downloadSources, {
+      forceAccountsRefresh,
+      forceRoomsRefresh,
+      forceEventsRefresh,
+    });
   };
 
   const isFormValid =
@@ -422,6 +457,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
     filePath.trim() !== '' &&
     hasSelectedDownloadSources(downloadSources);
   const profileHistoryEnabled = tokenStatus === 'verified';
+  const feedPhotosVisibilitySuffix =
+    tokenStatus === 'verified' ? '(Public & Private)' : '(Public)';
+  const resolvedProfilePhotoUrl =
+    usernameStatus === 'found' && resolvedAccount
+      ? buildCdnImageUrl(settings.cdnBase, resolvedAccount.profileImage)
+      : '';
 
   const renderDownloadType = (params: {
     id: string;
@@ -481,7 +522,8 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             Download Photos
           </DialogTitle>
           <DialogDescription>
-            Enter a token, username, save path, and choose what data to download.
+            Enter a token, username, save path, and choose what data to
+            download.
           </DialogDescription>
         </DialogHeader>
 
@@ -490,7 +532,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             <div className="flex items-center gap-2">
               <Label htmlFor="token" className="flex items-center gap-2">
                 <Key className="h-4 w-4" />
-                Token (Optional)
+                Bearer Token (Optional)
               </Label>
               <Button
                 type="button"
@@ -503,14 +545,26 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
                 <HelpCircle className="h-4 w-4" />
               </Button>
             </div>
-            <textarea
-              id="token"
-              placeholder="Enter your access token"
-              value={token}
-              onChange={handleTokenChange}
-              className="flex min-h-[2.5rem] max-h-[6rem] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-y overflow-y-auto"
-              rows={4}
-            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+              <textarea
+                ref={tokenTextareaRef}
+                id="token"
+                placeholder="Enter your access token"
+                value={token}
+                onChange={handleTokenChange}
+                className="flex min-h-[2.5rem] max-h-[6rem] min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-y overflow-y-auto"
+                rows={4}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-9 shrink-0 sm:mt-0"
+                onClick={() => void handlePasteToken()}
+              >
+                Paste Bearer Token
+              </Button>
+            </div>
             <p
               className={`text-sm ${
                 tokenStatus === 'invalid'
@@ -526,39 +580,73 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             </p>
             {tokenExpiringSoon && (
               <p className="text-sm text-red-600 dark:text-red-400">
-                Warning: Your token is expiring in 20 minutes or less. Please get
-                a fresh token.
+                Warning: Your token is expiring in 20 minutes or less. Please
+                get a fresh token.
               </p>
             )}
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="username">Username</Label>
+            <Label htmlFor="username">Rec Room @ Username</Label>
             <Input
               id="username"
               placeholder="Enter your username"
               value={username}
               onChange={handleUsernameChange}
             />
-            {usernameStatus === 'found' && (
-              <p className="text-sm text-green-600 dark:text-green-400">
-                Username found successfully.
-              </p>
-            )}
-            {usernameStatus === 'not-found' && (
-              <p className="text-sm text-red-600 dark:text-red-400">
-                Username not found.
-              </p>
-            )}
-            {usernameStatus === 'checking' && (
-              <p className="text-sm text-muted-foreground">
-                Checking username...
-              </p>
-            )}
+            <div className="space-y-2">
+              <div className="min-h-5">
+                {usernameStatus === 'found' && resolvedAccount && (
+                  <p className="text-sm text-green-600 dark:text-green-400">
+                    Account found successfully
+                  </p>
+                )}
+                {usernameStatus === 'not-found' && (
+                  <p className="text-sm text-red-600 dark:text-red-400">
+                    Username not found
+                  </p>
+                )}
+                {usernameStatus === 'checking' && (
+                  <p className="text-sm text-muted-foreground">
+                    Checking username...
+                  </p>
+                )}
+              </div>
+              <div className="flex min-h-[3.75rem] items-center">
+                {usernameStatus === 'found' && resolvedAccount && (
+                  <Card className="flex w-full flex-row items-center gap-2.5 p-2.5 shadow-none">
+                    {resolvedProfilePhotoUrl ? (
+                      <img
+                        src={resolvedProfilePhotoUrl}
+                        alt=""
+                        className="size-10 shrink-0 rounded-full object-cover ring-1 ring-border"
+                      />
+                    ) : (
+                      <div
+                        className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted ring-1 ring-border"
+                        aria-hidden
+                      >
+                        <UserRound className="size-5 text-muted-foreground" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium leading-tight">
+                        {resolvedAccount.displayName}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        @{resolvedAccount.username}
+                      </p>
+                    </div>
+                  </Card>
+                )}
+              </div>
+            </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="filepath">File Path</Label>
+            <Label htmlFor="filepath">
+              Where should the downloaded photos be saved?
+            </Label>
             <div className="flex gap-2">
               <Input
                 id="filepath"
@@ -579,10 +667,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              User photos save to <code className="font-mono">[folder]/[accountId]/photos</code>,
-              feed photos save to <code className="font-mono">[folder]/[accountId]/feed</code>,
-              and profile history saves to{' '}
-              <code className="font-mono">[folder]/[accountId]/profile-history</code>.
+              All photos and data are saved to the selected folder.
             </p>
           </div>
 
@@ -597,7 +682,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             <div className="space-y-2">
               {renderDownloadType({
                 id: 'download-user-feed',
-                title: 'User Feed',
+                title: `User Feed ${feedPhotosVisibilitySuffix}`,
                 description: 'Download photos the user was tagged in.',
                 checked: downloadSources.downloadUserFeed,
                 onChange: checked =>
@@ -605,7 +690,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               })}
               {renderDownloadType({
                 id: 'download-user-photos',
-                title: 'User Photos',
+                title: `User Photos ${feedPhotosVisibilitySuffix}`,
                 description: 'Download photos the user took.',
                 checked: downloadSources.downloadUserPhotos,
                 onChange: checked =>
@@ -649,8 +734,8 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             {advancedOpen && (
               <div className="border-t px-3 pb-3 pt-2 space-y-2">
                 <p className="text-sm text-muted-foreground">
-                  User, room, and event details are reused when available. Toggle
-                  below to force a fresh download.
+                  User, room, and event details are reused when available.
+                  Toggle below to force a fresh download.
                 </p>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <Button
@@ -694,12 +779,13 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
             )}
           </div>
 
-          {!isFormValid && (
-            <p className="text-sm text-muted-foreground">
-              Enter a username, choose a save folder, and select at least one
-              download type to start.
-            </p>
-          )}
+          <p
+            className={`text-sm text-muted-foreground ${isFormValid ? 'invisible' : ''}`}
+            aria-hidden={isFormValid}
+          >
+            Enter a username, choose a save folder, and select at least one
+            download type to start.
+          </p>
 
           <div className="flex gap-2">
             <Button
@@ -740,8 +826,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               </p>
               <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
                 <li>Log in to your RecNet account in a web browser.</li>
-                <li>Open your browser&apos;s Developer Tools and go to Network.</li>
-                <li>Navigate to any RecNet page that requires authentication.</li>
+                <li>
+                  Open your browser&apos;s Developer Tools and go to Network.
+                </li>
+                <li>
+                  Navigate to any RecNet page that requires authentication.
+                </li>
                 <li>Open one of the RecNet API requests.</li>
                 <li>Find the `Authorization` header in the request headers.</li>
                 <li>Copy the token value, usually after `Bearer `.</li>

--- a/src/renderer/components/ErrorRecoveryBanner.tsx
+++ b/src/renderer/components/ErrorRecoveryBanner.tsx
@@ -42,7 +42,8 @@ export const ErrorRecoveryBanner: React.FC<ErrorRecoveryBannerProps> = ({
     incident.source === 'download' &&
     canRetryDownload &&
     onRetryDownload &&
-    incident.category !== 'cancelled';
+    incident.category !== 'cancelled' &&
+    incident.category !== 'empty';
 
   const showRetryAfterCancel =
     incident.source === 'download' &&

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -42,7 +42,7 @@ interface PhotoViewerProps {
   cdnBase?: string;
 }
 
-type PhotoSource = 'photos' | 'feed';
+type PhotoSource = 'photos' | 'feed' | 'profile-history';
 
 export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   filePath,
@@ -81,6 +81,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const [accountMap, setAccountMap] = useState<Map<string, string>>(new Map());
   const [eventMap, setEventMap] = useState<Map<string, string>>(new Map());
   const [feedPhotos, setFeedPhotos] = useState<Photo[]>([]);
+  const [profileHistoryPhotos, setProfileHistoryPhotos] = useState<Photo[]>([]);
   const [photoSource, setPhotoSource] = useState<PhotoSource>('photos');
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const internalScrollRef = useRef<HTMLDivElement | null>(null);
@@ -103,7 +104,12 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
 
   // Use propAccountId if provided, otherwise use selectedAccountId
   const accountId = propAccountId || selectedAccountId;
-  const basePhotos = photoSource === 'feed' ? feedPhotos : photos;
+  const basePhotos =
+    photoSource === 'feed'
+      ? feedPhotos
+      : photoSource === 'profile-history'
+        ? profileHistoryPhotos
+        : photos;
 
   // Filter photos based on favorites filter
   const activePhotos = useMemo(() => {
@@ -111,7 +117,12 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     return basePhotos.filter(photo => favorites.has(photo.Id.toString()));
   }, [basePhotos, showFavoritesOnly, favorites]);
 
-  const activeViewLabel = photoSource === 'feed' ? 'feed photos' : 'photos';
+  const activeViewLabel =
+    photoSource === 'feed'
+      ? 'feed photos'
+      : photoSource === 'profile-history'
+        ? 'profile picture history'
+        : 'photos';
 
   const loadAvailableAccounts = useCallback(async () => {
     setLoadingAccounts(true);
@@ -227,6 +238,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     if (!filePath || !accountId) {
       setPhotos([]);
       setFeedPhotos([]);
+      setProfileHistoryPhotos([]);
       return;
     }
 
@@ -234,9 +246,11 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     setLoadError(null);
     try {
       if (electronAPI) {
-        const [photosResult, feedPhotosResult] = await Promise.all([
+        const [photosResult, feedPhotosResult, profileHistoryResult] =
+          await Promise.all([
           electronAPI.loadPhotos(accountId),
           electronAPI.loadFeedPhotos(accountId),
+          electronAPI.loadProfileHistoryPhotos(accountId),
         ]);
 
         if (photosResult.success && photosResult.data) {
@@ -250,10 +264,16 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         } else {
           setFeedPhotos([]);
         }
+        if (profileHistoryResult.success && profileHistoryResult.data) {
+          setProfileHistoryPhotos(profileHistoryResult.data);
+        } else {
+          setProfileHistoryPhotos([]);
+        }
         onPhotosLoadSuccessRef.current?.();
       } else {
         setPhotos([]);
         setFeedPhotos([]);
+        setProfileHistoryPhotos([]);
       }
     } catch (error) {
       const msg = `Failed to load photos: ${error instanceof Error ? error.message : 'Unknown error'}. Check that your output folder is accessible.`;
@@ -261,6 +281,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       onPhotosLoadErrorRef.current?.(msg);
       setPhotos([]);
       setFeedPhotos([]);
+      setProfileHistoryPhotos([]);
     } finally {
       setLoading(false);
     }
@@ -290,6 +311,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     } else {
       setPhotos([]);
       setFeedPhotos([]);
+      setProfileHistoryPhotos([]);
       setRoomMap(new Map());
       setAccountMap(new Map());
       setEventMap(new Map());
@@ -302,6 +324,34 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     loadAccountData,
     loadEventData,
   ]);
+
+  useEffect(() => {
+    if (!accountId) {
+      return;
+    }
+
+    if (photoSource === 'photos' && photos.length > 0) {
+      return;
+    }
+    if (photoSource === 'feed' && feedPhotos.length > 0) {
+      return;
+    }
+    if (photoSource === 'profile-history' && profileHistoryPhotos.length > 0) {
+      return;
+    }
+
+    if (photos.length > 0) {
+      setPhotoSource('photos');
+      return;
+    }
+    if (feedPhotos.length > 0) {
+      setPhotoSource('feed');
+      return;
+    }
+    if (profileHistoryPhotos.length > 0) {
+      setPhotoSource('profile-history');
+    }
+  }, [accountId, feedPhotos.length, photoSource, photos.length, profileHistoryPhotos.length]);
 
   // Reload photos + metadata periodically during download so names resolve
   useEffect(() => {
@@ -429,6 +479,15 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                 onClick={() => setPhotoSource('feed')}
               >
                 Feed ({feedPhotos.length})
+              </Button>
+              <Button
+                size="sm"
+                variant={
+                  photoSource === 'profile-history' ? 'default' : 'outline'
+                }
+                onClick={() => setPhotoSource('profile-history')}
+              >
+                Profile History ({profileHistoryPhotos.length})
               </Button>
               <Button
                 size="sm"

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -123,6 +123,11 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       : photoSource === 'profile-history'
         ? 'profile picture history'
         : 'photos';
+  const hasUserPhotos = photos.length > 0;
+  const hasFeedPhotos = feedPhotos.length > 0;
+  const hasProfileHistoryPhotos = profileHistoryPhotos.length > 0;
+  const hasPhotoSections =
+    hasUserPhotos || hasFeedPhotos || hasProfileHistoryPhotos;
 
   const loadAvailableAccounts = useCallback(async () => {
     setLoadingAccounts(true);
@@ -465,43 +470,55 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
             )}
 
             <div className="flex flex-wrap items-center gap-3 md:justify-end">
-              <span className="text-sm text-muted-foreground">Viewing</span>
-              <Button
-                size="sm"
-                variant={photoSource === 'photos' ? 'default' : 'outline'}
-                onClick={() => setPhotoSource('photos')}
-              >
-                My Photos ({photos.length})
-              </Button>
-              <Button
-                size="sm"
-                variant={photoSource === 'feed' ? 'default' : 'outline'}
-                onClick={() => setPhotoSource('feed')}
-              >
-                Feed ({feedPhotos.length})
-              </Button>
-              <Button
-                size="sm"
-                variant={
-                  photoSource === 'profile-history' ? 'default' : 'outline'
-                }
-                onClick={() => setPhotoSource('profile-history')}
-              >
-                Profile History ({profileHistoryPhotos.length})
-              </Button>
-              <Button
-                size="sm"
-                variant={showFavoritesOnly ? 'default' : 'outline'}
-                onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
-                className={
-                  showFavoritesOnly ? 'bg-red-500 text-white hover:bg-red-600' : ''
-                }
-              >
-                <Heart
-                  className={`mr-2 h-4 w-4 ${showFavoritesOnly ? 'fill-current' : ''}`}
-                />
-                Favorites
-              </Button>
+              {hasPhotoSections && (
+                <>
+                  <span className="text-sm text-muted-foreground">Viewing</span>
+                  {hasUserPhotos && (
+                    <Button
+                      size="sm"
+                      variant={photoSource === 'photos' ? 'default' : 'outline'}
+                      onClick={() => setPhotoSource('photos')}
+                    >
+                      My Photos ({photos.length})
+                    </Button>
+                  )}
+                  {hasFeedPhotos && (
+                    <Button
+                      size="sm"
+                      variant={photoSource === 'feed' ? 'default' : 'outline'}
+                      onClick={() => setPhotoSource('feed')}
+                    >
+                      Feed ({feedPhotos.length})
+                    </Button>
+                  )}
+                  {hasProfileHistoryPhotos && (
+                    <Button
+                      size="sm"
+                      variant={
+                        photoSource === 'profile-history' ? 'default' : 'outline'
+                      }
+                      onClick={() => setPhotoSource('profile-history')}
+                    >
+                      Profile History ({profileHistoryPhotos.length})
+                    </Button>
+                  )}
+                  <Button
+                    size="sm"
+                    variant={showFavoritesOnly ? 'default' : 'outline'}
+                    onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+                    className={
+                      showFavoritesOnly
+                        ? 'bg-red-500 text-white hover:bg-red-600'
+                        : ''
+                    }
+                  >
+                    <Heart
+                      className={`mr-2 h-4 w-4 ${showFavoritesOnly ? 'fill-current' : ''}`}
+                    />
+                    Favorites
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/src/renderer/components/ResultsPanel.tsx
+++ b/src/renderer/components/ResultsPanel.tsx
@@ -69,7 +69,8 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
         isDownloadOp &&
         canRetryDownload &&
         onRetryDownload &&
-        errorData.category !== 'cancelled';
+        errorData.category !== 'cancelled' &&
+        errorData.category !== 'empty';
 
       return (
         <div className="flex flex-col gap-3">

--- a/src/renderer/components/ResultsPanel.tsx
+++ b/src/renderer/components/ResultsPanel.tsx
@@ -147,6 +147,8 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
       saved?: string;
       photosDirectory?: string;
       feedPhotosDirectory?: string;
+      profileHistoryDirectory?: string;
+      profileHistoryManifestPath?: string;
       guidance?: string[];
     };
 
@@ -232,6 +234,24 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
             <Info className="w-4 h-4 text-blue-600 dark:text-blue-400" />
             <span className="text-blue-600 dark:text-blue-400 text-sm">
               Feed: {data.feedPhotosDirectory}
+            </span>
+          </div>
+        )}
+
+        {data.profileHistoryDirectory && (
+          <div className="flex items-center gap-2">
+            <Info className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+            <span className="text-blue-600 dark:text-blue-400 text-sm">
+              Profile history: {data.profileHistoryDirectory}
+            </span>
+          </div>
+        )}
+
+        {data.profileHistoryManifestPath && (
+          <div className="flex items-center gap-2">
+            <Info className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+            <span className="text-blue-600 dark:text-blue-400 text-sm">
+              Manifest: {data.profileHistoryManifestPath}
             </span>
           </div>
         )}

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '../lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 max-w-xs overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/renderer/utils/__tests__/errorPresentation.test.ts
+++ b/src/renderer/utils/__tests__/errorPresentation.test.ts
@@ -1,0 +1,37 @@
+import {
+  classifyError,
+  createUserIncident,
+} from '../errorPresentation';
+
+describe('errorPresentation', () => {
+  it('classifies empty user photo downloads as a friendly warning state', () => {
+    const result = classifyError(
+      'This account does not have any user photos to download.',
+      'download'
+    );
+
+    expect(result).toEqual({
+      category: 'empty',
+      title: 'No user photos found',
+      detail: 'This account does not have any user photos to download.',
+      guidance: [
+        'You can still download other sections for this account.',
+        'Try another account if you expected photos to be available here.',
+      ],
+    });
+  });
+
+  it('defaults empty download incidents to warning severity', () => {
+    const incident = createUserIncident(
+      'download',
+      'This account does not have any feed photos to download.'
+    );
+
+    expect(incident.severity).toBe('warning');
+    expect(incident.category).toBe('empty');
+    expect(incident.title).toBe('No feed photos found');
+    expect(incident.detail).toBe(
+      'This account does not have any feed photos to download.'
+    );
+  });
+});

--- a/src/renderer/utils/errorPresentation.ts
+++ b/src/renderer/utils/errorPresentation.ts
@@ -11,6 +11,28 @@ const DOWNLOAD_RESUME = [
   'You do not need to delete the output folder to resume.',
 ] as const;
 
+/** Collapses whitespace so minor formatting differences still match known copy. */
+function normalizeEmptyDownloadMessage(message: string): string {
+  return message
+    .trim()
+    .replace(/\.$/, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+/** Canonical empty-download messages; value is which variant to show in the UI. */
+const EMPTY_DOWNLOAD_KIND = new Map<string, 'feed' | 'user'>([
+  ['this account does not have any user photos to download', 'user'],
+  ['this account does not have any feed photos to download', 'feed'],
+  ['this account does not have any photos to download', 'user'],
+  ['no photos found in the json file', 'user'],
+  ['no feed photos found in the json file', 'feed'],
+]);
+
+function emptyDownloadKind(message: string): 'feed' | 'user' | null {
+  return EMPTY_DOWNLOAD_KIND.get(normalizeEmptyDownloadMessage(message)) ?? null;
+}
+
 function truncateDetail(s: string, max = 220): string {
   const t = s.trim();
   if (t.length <= max) return t;
@@ -42,6 +64,7 @@ function pickTitle(context: ErrorContext, category: UserErrorCategory): string {
   if (category === 'cancelled') return 'Download cancelled';
 
   if (context === 'download') {
+    if (category === 'empty') return 'No photos found';
     if (category === 'account') return 'We could not find that account';
     if (category === 'auth') return 'Access was denied';
     if (category === 'network') return 'Could not reach RecNet';
@@ -62,6 +85,13 @@ function buildGuidance(
   const g: string[] = [];
 
   if (context === 'download') {
+    if (category === 'empty') {
+      g.push('You can still download other sections for this account.');
+      g.push(
+        'Try another account if you expected photos to be available here.'
+      );
+      return g;
+    }
     if (category !== 'cancelled') {
       g.push(...DOWNLOAD_RESUME);
     }
@@ -152,6 +182,20 @@ export function classifyError(
     };
   }
 
+  const emptyKind = context === 'download' ? emptyDownloadKind(message) : null;
+  if (emptyKind !== null) {
+    return {
+      category: 'empty',
+      title:
+        emptyKind === 'feed' ? 'No feed photos found' : 'No user photos found',
+      detail:
+        emptyKind === 'feed'
+          ? 'This account does not have any feed photos to download.'
+          : 'This account does not have any user photos to download.',
+      guidance: buildGuidance(context, 'empty', message),
+    };
+  }
+
   const category = detectCategory(message);
   const title = pickTitle(context, category);
   const detail = truncateDetail(message);
@@ -180,7 +224,10 @@ export function createUserIncident(
 ): UserFacingIncident {
   const c = classifyError(rawMessage, source);
   const severity =
-    options?.severity ?? (c.category === 'cancelled' ? 'warning' : 'error');
+    options?.severity ??
+    (c.category === 'cancelled' || c.category === 'empty'
+      ? 'warning'
+      : 'error');
   return {
     id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
     source,

--- a/src/shared/__tests__/download-sources.test.ts
+++ b/src/shared/__tests__/download-sources.test.ts
@@ -1,0 +1,61 @@
+import {
+  DEFAULT_DOWNLOAD_SOURCE_SELECTION,
+  getSelectedDownloadSources,
+  hasSelectedDownloadSources,
+} from '../download-sources';
+
+describe('download source selection helpers', () => {
+  it('defaults to feed and user photos only', () => {
+    expect(DEFAULT_DOWNLOAD_SOURCE_SELECTION).toEqual({
+      downloadUserFeed: true,
+      downloadUserPhotos: true,
+      downloadProfileHistory: false,
+    });
+  });
+
+  it('returns sources in feed, photos, profile history order', () => {
+    expect(
+      getSelectedDownloadSources({
+        downloadUserFeed: true,
+        downloadUserPhotos: true,
+        downloadProfileHistory: true,
+      })
+    ).toEqual(['user-feed', 'user-photos', 'profile-history']);
+  });
+
+  it('supports feed-only and photos-only selections', () => {
+    expect(
+      getSelectedDownloadSources({
+        downloadUserFeed: true,
+        downloadUserPhotos: false,
+        downloadProfileHistory: false,
+      })
+    ).toEqual(['user-feed']);
+
+    expect(
+      getSelectedDownloadSources({
+        downloadUserFeed: false,
+        downloadUserPhotos: true,
+        downloadProfileHistory: false,
+      })
+    ).toEqual(['user-photos']);
+  });
+
+  it('detects whether at least one source is selected', () => {
+    expect(
+      hasSelectedDownloadSources({
+        downloadUserFeed: false,
+        downloadUserPhotos: false,
+        downloadProfileHistory: false,
+      })
+    ).toBe(false);
+
+    expect(
+      hasSelectedDownloadSources({
+        downloadUserFeed: false,
+        downloadUserPhotos: false,
+        downloadProfileHistory: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/shared/download-sources.ts
+++ b/src/shared/download-sources.ts
@@ -1,0 +1,44 @@
+export interface DownloadSourceSelection {
+  downloadUserFeed: boolean;
+  downloadUserPhotos: boolean;
+  downloadProfileHistory: boolean;
+}
+
+export type DownloadSource =
+  | 'user-feed'
+  | 'user-photos'
+  | 'profile-history';
+
+export const DEFAULT_DOWNLOAD_SOURCE_SELECTION: DownloadSourceSelection = {
+  downloadUserFeed: true,
+  downloadUserPhotos: true,
+  downloadProfileHistory: false,
+};
+
+export function hasSelectedDownloadSources(
+  selection: DownloadSourceSelection
+): boolean {
+  return (
+    selection.downloadUserFeed ||
+    selection.downloadUserPhotos ||
+    selection.downloadProfileHistory
+  );
+}
+
+export function getSelectedDownloadSources(
+  selection: DownloadSourceSelection
+): DownloadSource[] {
+  const sources: DownloadSource[] = [];
+
+  if (selection.downloadUserFeed) {
+    sources.push('user-feed');
+  }
+  if (selection.downloadUserPhotos) {
+    sources.push('user-photos');
+  }
+  if (selection.downloadProfileHistory) {
+    sources.push('profile-history');
+  }
+
+  return sources;
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -10,6 +10,7 @@ import type {
   DownloadResult,
   EventDto,
   Photo,
+  ProfileHistoryAccessResult,
   PlayerResult,
   Progress,
   RecNetSettings,
@@ -36,6 +37,14 @@ export interface ElectronAPI {
 
   downloadPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;
   downloadFeedPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;
+  downloadProfileHistory: (params: {
+    accountId: string;
+    token: string;
+  }) => Promise<ApiResponse<DownloadResult>>;
+  validateProfileHistoryAccess: (params: {
+    username: string;
+    token: string;
+  }) => Promise<ApiResponse<ProfileHistoryAccessResult>>;
 
   selectOutputFolder: () => Promise<string | null>;
   getSettings: () => Promise<RecNetSettings>;
@@ -54,6 +63,7 @@ export interface ElectronAPI {
   clearAccountData: (accountId: string) => Promise<ApiResponse<{ filesRemoved: number }>>;
   loadPhotos: (accountId: string) => Promise<ApiResponse<Photo[]>>;
   loadFeedPhotos: (accountId: string) => Promise<ApiResponse<Photo[]>>;
+  loadProfileHistoryPhotos: (accountId: string) => Promise<ApiResponse<Photo[]>>;
   listAvailableAccounts: () => Promise<ApiResponse<AvailableAccount[]>>;
   loadAccountsData: (accountId: string) => Promise<ApiResponse<PlayerResult[]>>;
   loadRoomsData: (accountId: string) => Promise<ApiResponse<RoomDto[]>>;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -144,6 +144,7 @@ export type ErrorContext =
   | 'updateSettings';
 
 export type UserErrorCategory =
+  | 'empty'
   | 'auth'
   | 'network'
   | 'account'

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -115,11 +115,19 @@ export interface DownloadResult {
   accountId: string;
   photosDirectory?: string;
   feedPhotosDirectory?: string;
+  profileHistoryDirectory?: string;
+  profileHistoryManifestPath?: string;
   processedCount: number;
   downloadStats: DownloadStats;
   downloadResults: DownloadResultItem[];
   totalResults: number;
   guidance?: string[];
+}
+
+export interface ProfileHistoryAccessResult {
+  accountId: string;
+  username: string;
+  tokenAccountId: string;
 }
 
 export interface ApiResponse<T> {
@@ -168,8 +176,10 @@ export interface AvailableAccount {
   accountId: string;
   hasPhotos: boolean;
   hasFeed: boolean;
+  hasProfileHistory: boolean;
   photoCount: number;
   feedCount: number;
+  profileHistoryCount: number;
   /**
    * Optional human-friendly label for the folder owner.
    * Populated from per-folder metadata when available.


### PR DESCRIPTION
- Modified the flow for downloading images
- Added user card below username input for quick verification that the username matches what you expect via profile photo and display name.
- Updated download flow to allow users to download either user photos, user feed photos, or profile picture history (this one requires a valid bearer token).
- Improved messaging when attempting to download images for a user that has none
- Added a 'paste' button next to the bearer token input field since Electron doesn't support 'right click > paste' 