### PR TITLE
fix: moved from 100k grabs to 2.5k to increase chance of success

### DIFF
--- a/src/main/services/recnet/http-client.ts
+++ b/src/main/services/recnet/http-client.ts
@@ -2,7 +2,10 @@ import { AxiosRequestConfig } from 'axios';
 import { GenericResponse } from '../../models/GenericResponse';
 import { axiosRequest } from '../../utils/axiosRequest';
 
-export const UNIVERSAL_BATCH_SIZE = 100_000;
+// Metadata bulk endpoints are more reliable with smaller payloads. Large
+// requests make partial failures harder to diagnose and can silently leave
+// account/room/event caches incomplete on very large libraries. (originally was 100,000)
+export const UNIVERSAL_BATCH_SIZE = 2_500;
 export interface RecNetRequestOptions {
   signal?: AbortSignal;
   timeoutMs?: number;


### PR DESCRIPTION
Batches of 100_000 can cause errors for users with lots of accounts.  2_500 is save and still fast for the average user.