### PR TITLE
refactor(download summary): updated the download image flow

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,8 +14,10 @@ import { autoUpdater } from 'electron-updater';
 import { RecNetService } from './services/recnet-service';
 import {
   CollectionResult,
+  DownloadPreflightSummary,
   DownloadResult,
   ProfileHistoryAccessResult,
+  ProfileHistoryCollectionResult,
   RecNetSettings,
   Progress,
   AccountInfo,
@@ -23,6 +25,7 @@ import {
   PlayerResult,
   RoomDto,
 } from '../shared/types';
+import type { DownloadSourceSelection } from '../shared/download-sources';
 import { EventDto } from './models/EventDto';
 
 // Keep a global reference of the window object
@@ -55,6 +58,11 @@ interface DownloadPhotosParams {
 interface ValidateProfileHistoryAccessParams {
   username: string;
   token: string;
+}
+
+interface BuildDownloadPreflightParams {
+  accountId: string;
+  downloadSources: DownloadSourceSelection;
 }
 
 interface ApiResponse<T> {
@@ -396,6 +404,42 @@ ipcMain.handle(
           forceRoomsRefresh: params.forceRoomsRefresh,
           forceEventsRefresh: params.forceEventsRefresh,
         }
+      );
+      return { success: true, data: result };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+);
+
+ipcMain.handle(
+  'collect-profile-history-manifest',
+  async (
+    event: IpcMainInvokeEvent,
+    params: ValidateProfileHistoryAccessParams & { accountId: string }
+  ): Promise<ApiResponse<ProfileHistoryCollectionResult>> => {
+    try {
+      const result = await recNetService.collectProfileHistoryManifest(
+        params.accountId,
+        params.token
+      );
+      return { success: true, data: result };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+);
+
+ipcMain.handle(
+  'build-download-preflight',
+  async (
+    event: IpcMainInvokeEvent,
+    params: BuildDownloadPreflightParams
+  ): Promise<ApiResponse<DownloadPreflightSummary>> => {
+    try {
+      const result = await recNetService.buildDownloadPreflightSummary(
+        params.accountId,
+        params.downloadSources
       );
       return { success: true, data: result };
     } catch (error) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -4,6 +4,10 @@ import type { ElectronAPI } from '../shared/electron-api';
 const electronAPI: ElectronAPI = {
   collectPhotos: (params) => ipcRenderer.invoke('collect-photos', params),
   collectFeedPhotos: (params) => ipcRenderer.invoke('collect-feed-photos', params),
+  collectProfileHistoryManifest: (params) =>
+    ipcRenderer.invoke('collect-profile-history-manifest', params),
+  buildDownloadPreflight: (params) =>
+    ipcRenderer.invoke('build-download-preflight', params),
 
   downloadPhotos: (params) => ipcRenderer.invoke('download-photos', params),
   downloadFeedPhotos: (params) => ipcRenderer.invoke('download-feed-photos', params),

--- a/src/main/services/__tests__/recnet-service.download.test.ts
+++ b/src/main/services/__tests__/recnet-service.download.test.ts
@@ -900,6 +900,75 @@ describe('RecNetService - Download Functionality', () => {
     });
   });
 
+  describe('collectPhotos metadata retries', () => {
+    const createMetadataPhoto = (id: string, imageName: string): ImageDto => ({
+      Id: id,
+      Type: 1,
+      Accessibility: 0,
+      AccessibilityLocked: false,
+      ImageName: imageName,
+      Description: '',
+      PlayerId: 'player-123',
+      TaggedPlayerIds: [],
+      RoomId: 'room-123',
+      PlayerEventId: 'event-123',
+      CreatedAt: new Date().toISOString(),
+      CheerCount: 0,
+      CommentCount: 0,
+    });
+
+    it('retries failed metadata page requests and recovers cleanly', async () => {
+      const progressUpdates: Progress[] = [];
+      service.on('progress-update', progress => progressUpdates.push(progress));
+      jest.spyOn(service, 'fetchAndSaveBulkData').mockResolvedValue({
+        accountsFetched: 0,
+        roomsFetched: 0,
+        eventsFetched: 0,
+      });
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+
+      mockPhotosController.fetchPlayerPhotos
+        .mockRejectedValueOnce(new Error('Temporary outage'))
+        .mockResolvedValueOnce([createMetadataPhoto('photo-1', 'image1.jpg')]);
+
+      const result = await service.collectPhotos(testAccountId);
+
+      expect(result.totalPhotos).toBe(1);
+      expect(mockPhotosController.fetchPlayerPhotos).toHaveBeenCalledTimes(2);
+      expect(
+        progressUpdates.some(progress =>
+          progress.lastIssue?.includes(
+            'Issue collecting user photos page 1: Temporary outage. Retry 1/3 will start now.'
+          )
+        )
+      ).toBe(true);
+      expect(
+        progressUpdates.some(progress =>
+          progress.lastIssue?.includes(
+            'Recovered user photos page 1 after 1 retry. Metadata collection is continuing.'
+          )
+        )
+      ).toBe(true);
+    });
+
+    it('fails metadata collection after exhausting retries', async () => {
+      jest.spyOn(service, 'fetchAndSaveBulkData').mockResolvedValue({
+        accountsFetched: 0,
+        roomsFetched: 0,
+        eventsFetched: 0,
+      });
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+      mockPhotosController.fetchPlayerPhotos.mockRejectedValue(
+        new Error('Temporary outage')
+      );
+
+      await expect(service.collectPhotos(testAccountId)).rejects.toThrow(
+        'Failed to collect user photos page 1 after 3 retries: Temporary outage'
+      );
+      expect(mockPhotosController.fetchPlayerPhotos).toHaveBeenCalledTimes(4);
+    });
+  });
+
   /**
    * Tests for the downloadFeedPhotos method
    *
@@ -995,6 +1064,52 @@ describe('RecNetService - Download Functionality', () => {
       expect(result.downloadStats.retryAttempts).toBe(3);
       expect(result.downloadResults[0].attempts).toBe(4);
       expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(4);
+    });
+
+    it('should stop the whole feed download when the disk is full', async () => {
+      service.updateSettings({
+        outputRoot: testOutputDir,
+        maxConcurrentDownloads: 1,
+      });
+
+      const feedPhotos: ImageDto[] = [
+        createMockFeedPhoto('feed-1', 'feed1.jpg'),
+        createMockFeedPhoto('feed-2', 'feed2.jpg'),
+      ];
+
+      const feedJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_feed.json`
+      );
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === feedJsonPath) return true;
+        return false;
+      });
+
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(feedPhotos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+
+      const diskFullError = Object.assign(
+        new Error('ENOSPC: no space left on device'),
+        { code: 'ENOSPC' }
+      );
+      (mockedFs.writeFile as jest.Mock)
+        .mockRejectedValueOnce(diskFullError)
+        .mockResolvedValue(undefined);
+
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: true,
+        value: new ArrayBuffer(1024),
+        status: 200,
+      } as GenericResponse<ArrayBuffer>);
+
+      await expect(service.downloadFeedPhotos(testAccountId)).rejects.toThrow(
+        /no space left on your disk/i
+      );
+      expect(mockedFs.writeFile).toHaveBeenCalledTimes(1);
+      expect(mockPhotosController.downloadPhoto).toHaveBeenCalledTimes(1);
     });
 
     /**
@@ -1113,7 +1228,7 @@ describe('RecNetService - Download Functionality', () => {
     });
   });
 
-  describe('downloadProfileHistory', () => {
+  describe('profile history preflight and download', () => {
     const createProfileHistoryEntry = (id: number, imageName: string) => ({
       Id: id,
       Type: 4,
@@ -1130,7 +1245,35 @@ describe('RecNetService - Download Functionality', () => {
       CommentCount: 0,
     });
 
-    it('saves the manifest and downloads profile history images', async () => {
+    it('collects the manifest before downloading profile history images', async () => {
+      const historyPayload = [
+        createProfileHistoryEntry(85498573, 'avatar1.jpg'),
+        createProfileHistoryEntry(85498574, 'avatar2.jpg'),
+      ];
+      const manifestPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_profile_history.json`
+      );
+
+      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+
+      const result = await service.collectProfileHistoryManifest(
+        testAccountId,
+        'token'
+      );
+
+      expect(result.saved).toBe(manifestPath);
+      expect(result.totalPhotos).toBe(2);
+      expect(mockedFs.writeJson).toHaveBeenCalledWith(
+        manifestPath,
+        historyPayload,
+        { spaces: 2 }
+      );
+    });
+
+    it('downloads profile history images from an existing manifest', async () => {
       const historyPayload = [
         createProfileHistoryEntry(85498573, 'avatar1.jpg'),
         createProfileHistoryEntry(85498574, 'avatar2.jpg'),
@@ -1146,13 +1289,18 @@ describe('RecNetService - Download Functionality', () => {
         `${testAccountId}_profile_history.json`
       );
 
-      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
       mockPhotosController.downloadPhoto.mockResolvedValue({
         success: true,
         value: new ArrayBuffer(512),
         status: 200,
       } as GenericResponse<ArrayBuffer>);
-      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === manifestPath) {
+          return true;
+        }
+        return false;
+      });
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(historyPayload);
       (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
 
       const result = await service.downloadProfileHistory(testAccountId, 'token');
@@ -1160,16 +1308,17 @@ describe('RecNetService - Download Functionality', () => {
       expect(result.profileHistoryDirectory).toBe(profileHistoryDir);
       expect(result.profileHistoryManifestPath).toBe(manifestPath);
       expect(result.downloadStats.newDownloads).toBe(2);
-      expect(mockedFs.writeJson).toHaveBeenCalledWith(
-        manifestPath,
-        historyPayload,
-        { spaces: 2 }
-      );
       expect(mockedFs.writeFile).toHaveBeenCalledTimes(2);
+      expect(mockPhotosController.fetchProfilePhotoHistory).not.toHaveBeenCalled();
     });
 
     it('skips already-downloaded profile history images on rerun', async () => {
       const historyPayload = [createProfileHistoryEntry(85498573, 'avatar1.jpg')];
+      const manifestPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_profile_history.json`
+      );
       const existingPhotoPath = path.join(
         testOutputDir,
         testAccountId,
@@ -1177,13 +1326,16 @@ describe('RecNetService - Download Functionality', () => {
         '85498573.jpg'
       );
 
-      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
       (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === manifestPath) {
+          return true;
+        }
         if (p === existingPhotoPath) {
           return true;
         }
         return false;
       });
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(historyPayload);
       (mockedFs.readdir as jest.Mock).mockResolvedValue(['85498573.jpg']);
 
       const result = await service.downloadProfileHistory(testAccountId, 'token');
@@ -1195,15 +1347,25 @@ describe('RecNetService - Download Functionality', () => {
 
     it('retries failed profile history downloads before reporting failure', async () => {
       const historyPayload = [createProfileHistoryEntry(85498573, 'avatar1.jpg')];
+      const manifestPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_profile_history.json`
+      );
 
-      mockPhotosController.fetchProfilePhotoHistory.mockResolvedValue(historyPayload);
       mockPhotosController.downloadPhoto.mockResolvedValue({
         success: false,
         value: null,
         status: 500,
         error: 'CDN failure',
       } as GenericResponse<ArrayBuffer>);
-      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+      (mockedFs.pathExists as jest.Mock).mockImplementation(async (p: string) => {
+        if (p === manifestPath) {
+          return true;
+        }
+        return false;
+      });
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(historyPayload);
       (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
 
       const result = await service.downloadProfileHistory(testAccountId, 'token');
@@ -1221,14 +1383,13 @@ describe('RecNetService - Download Functionality', () => {
       ).rejects.toThrow('Profile picture history requires a valid access token.');
     });
 
-    it('rejects unauthorized profile history requests', async () => {
+    it('rejects unauthorized manifest collection requests', async () => {
       mockPhotosController.fetchProfilePhotoHistory.mockRejectedValue(
         new Error('HTTP 401: Unauthorized')
       );
-      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
 
       await expect(
-        service.downloadProfileHistory(testAccountId, 'token')
+        service.collectProfileHistoryManifest(testAccountId, 'token')
       ).rejects.toThrow('HTTP 401: Unauthorized');
     });
   });

--- a/src/main/services/__tests__/recnet-service.save.test.ts
+++ b/src/main/services/__tests__/recnet-service.save.test.ts
@@ -6,7 +6,7 @@
  * - File sizes are tracked accurately
  * - Directories are created as needed
  * - Multiple files can be saved in sequence
- * - File write errors are handled gracefully
+   * - Out-of-space write errors stop the download with a clear error
  * - Metadata JSON files are saved with proper formatting
  *
  * These tests ensure data persistence works correctly and files are
@@ -224,11 +224,10 @@ describe('RecNetService - File Saving Functionality', () => {
     });
 
     /**
-     * Verifies that file write errors (e.g., disk full, permissions) are caught
-     * and recorded in the results rather than crashing the entire download process.
-     * Other photos should continue downloading even if one fails to save.
+     * Verifies that a disk-full write error stops the download immediately
+     * with a clear message so the user can free space before retrying.
      */
-    it('should handle file write errors gracefully', async () => {
+    it('should stop the download when the disk is full', async () => {
       const photos: ImageDto[] = [createMockPhoto('photo-1', 'image1.jpg')];
 
       const photosJsonPath = path.join(
@@ -246,9 +245,11 @@ describe('RecNetService - File Saving Functionality', () => {
 
       (mockedFs.readJson as jest.Mock).mockResolvedValue(photos);
       (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
-      (mockedFs.writeFile as jest.Mock).mockRejectedValue(
-        new Error('Disk full')
+      const diskFullError = Object.assign(
+        new Error('ENOSPC: no space left on device'),
+        { code: 'ENOSPC' }
       );
+      (mockedFs.writeFile as jest.Mock).mockRejectedValueOnce(diskFullError);
 
       mockPhotosController.downloadPhoto.mockResolvedValue({
         success: true,
@@ -256,10 +257,9 @@ describe('RecNetService - File Saving Functionality', () => {
         status: 200,
       } as GenericResponse<ArrayBuffer>);
 
-      const result = await service.downloadPhotos(testAccountId);
-
-      expect(result.downloadStats.failedDownloads).toBeGreaterThan(0);
-      expect(result.downloadResults[0].status).toBe('error');
+      await expect(service.downloadPhotos(testAccountId)).rejects.toThrow(
+        /no space left on your disk/i
+      );
     });
 
     /**

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -6,8 +6,11 @@ import {
   RecNetSettings,
   Progress,
   CollectionResult,
+  DownloadPreflightSourceSummary,
+  DownloadPreflightSummary,
   DownloadResult,
   ProfileHistoryAccessResult,
+  ProfileHistoryCollectionResult,
   Photo,
   IterationDetail,
   DownloadResultItem,
@@ -16,6 +19,11 @@ import {
   BulkDataRefreshOptions,
 } from '../../shared/types';
 import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
+import {
+  DownloadSource,
+  DownloadSourceSelection,
+  getSelectedDownloadSources,
+} from '../../shared/download-sources';
 import { EventDto } from '../models/EventDto';
 import { ImageDto } from '../models/ImageDto';
 import { PlayerResult } from '../models/PlayerDto';
@@ -32,6 +40,10 @@ interface CurrentOperation {
   cancelled: boolean;
   controller: AbortController;
 }
+
+type ErrorWithCode = Error & {
+  code?: string;
+};
 
 interface PhotoDownloadAttempt {
   response?: {
@@ -87,7 +99,6 @@ const PHOTO_DOWNLOAD_MAX_ATTEMPTS = PHOTO_DOWNLOAD_RETRY_COUNT + 1;
 const PHOTO_DOWNLOAD_RETRY_DELAY_MS = 750;
 const PHOTO_DOWNLOAD_TIMEOUT_MS = 15_000;
 const PHOTO_MAX_PAGE_SIZE = 1_000;
-
 function normalizeRecNetSettings(input: unknown): RecNetSettings {
   const raw =
     input && typeof input === 'object'
@@ -146,6 +157,7 @@ export class RecNetService extends EventEmitter {
     this.settings = { ...DEFAULT_SETTINGS };
     this.progress = this.createProgressState({
       isRunning: false,
+      phase: 'complete',
       currentStep: '',
       progress: 0,
       total: 0,
@@ -223,7 +235,8 @@ export class RecNetService extends EventEmitter {
     step: string,
     current: number,
     total: number,
-    progress?: number
+    progress?: number,
+    overrides: Partial<Progress> = {}
   ): void {
     if (!this.currentOperation || this.currentOperation.cancelled) {
       return;
@@ -235,6 +248,7 @@ export class RecNetService extends EventEmitter {
       current,
       total,
       progress: progress || (total > 0 ? (current / total) * 100 : 0),
+      ...overrides,
     });
     this.emit('progress-update', this.progress);
   }
@@ -243,10 +257,15 @@ export class RecNetService extends EventEmitter {
     this.progress = this.createProgressState({
       ...this.progress,
       isRunning: false,
+      phase: 'complete',
       currentStep: 'Complete',
       current: 0,
       total: 0,
       progress: 100,
+      currentSource: undefined,
+      pageLabel: undefined,
+      activeItemLabel: undefined,
+      confirmation: undefined,
     });
     this.emit('progress-update', this.progress);
   }
@@ -255,6 +274,7 @@ export class RecNetService extends EventEmitter {
     this.progress = this.createProgressState({
       ...this.progress,
       isRunning: false,
+      phase: 'failed',
       currentStep: 'Failed',
       current: 0,
       total: 0,
@@ -263,6 +283,7 @@ export class RecNetService extends EventEmitter {
       issueCount: Math.max(this.progress.issueCount, 1),
       failedItems: Math.max(this.progress.failedItems, 1),
       lastIssue: message,
+      confirmation: undefined,
     });
     this.emit('progress-update', this.progress);
   }
@@ -274,10 +295,12 @@ export class RecNetService extends EventEmitter {
       this.progress = this.createProgressState({
         ...this.progress,
         isRunning: false,
+        phase: 'cancelled',
         currentStep: 'Cancelled',
         current: 0,
         total: 0,
         progress: 100,
+        confirmation: undefined,
       });
       this.emit('progress-update', this.progress);
       return true;
@@ -311,6 +334,38 @@ export class RecNetService extends EventEmitter {
     );
   }
 
+  private isOutOfDiskSpaceError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+
+    const code = ((error as ErrorWithCode).code || '').toUpperCase();
+    const message = error.message || '';
+    return (
+      code === 'ENOSPC' ||
+      /ENOSPC|no space|disk full|disk is full|drive is full/i.test(message)
+    );
+  }
+
+  private abortOperationForDiskFull(
+    imageLabel: string,
+    operation?: CurrentOperation
+  ): never {
+    const targetOperation =
+      operation && this.currentOperation === operation
+        ? operation
+        : this.currentOperation;
+
+    if (targetOperation && !targetOperation.cancelled) {
+      targetOperation.cancelled = true;
+      targetOperation.controller.abort();
+    }
+
+    throw new Error(
+      `The download stopped because there is no space left on your disk while saving ${imageLabel}. Free up space and run the same download again. Anything already saved will be skipped automatically.`
+    );
+  }
+
   private isCancelledResponse(response?: {
     error?: string | null;
     message?: string | null;
@@ -336,7 +391,17 @@ export class RecNetService extends EventEmitter {
 
     try {
       this.resetProgressIssueState();
-      this.updateProgress('Downloading user photo data...', 0, 0, 0);
+      this.updateSourceProgress(
+        'metadata',
+        'user-photos',
+        'Collecting user photos metadata...',
+        0,
+        0,
+        0,
+        {
+          recentActivity: 'Preparing to collect user photos metadata...',
+        }
+      );
 
       const all: Photo[] = [];
       let skip = 0;
@@ -440,11 +505,20 @@ export class RecNetService extends EventEmitter {
           throw this.createOperationCancelledError();
         }
 
+        const pageNumber = iteration + 1;
         const modeText = isIncrementalMode ? ' (incremental)' : '';
-        this.updateProgress(
-          `Fetching page ${iteration + 1}${modeText}...`,
+        const pageLabel = `Page ${pageNumber}${modeText}`;
+        this.updateSourceProgress(
+          'metadata',
+          'user-photos',
+          'Collecting user photos metadata...',
           iteration,
-          0 // Total unknown since we loop until done
+          0,
+          undefined,
+          {
+            pageLabel,
+            recentActivity: `Checking ${pageLabel.toLowerCase()} for user photos...`,
+          }
         );
 
         let url = `https://apim.rec.net/apis/api/images/v4/player/${encodeURIComponent(
@@ -456,12 +530,20 @@ export class RecNetService extends EventEmitter {
         }
 
         const photos = this.normalizePhotos(
-          await this.photosController.fetchPlayerPhotos(
-            accountId,
-            { skip, take: PHOTO_MAX_PAGE_SIZE, sort: 2, after: lastSortValue },
-            token,
-            { signal: operation.controller.signal }
-          )
+          await this.runMetadataRequestWithRetry({
+            label: `user photos page ${pageNumber}`,
+            source: 'user-photos',
+            operationRef: operation,
+            pageLabel,
+            recentActivity: `Collected ${pageLabel.toLowerCase()} for user photos metadata.`,
+            operation: () =>
+              this.photosController.fetchPlayerPhotos(
+                accountId,
+                { skip, take: PHOTO_MAX_PAGE_SIZE, sort: 2, after: lastSortValue },
+                token,
+                { signal: operation.controller.signal }
+              ),
+          })
         );
         if (!Array.isArray(photos)) {
           throw new Error('Unexpected response format: expected array');
@@ -511,7 +593,7 @@ export class RecNetService extends EventEmitter {
         totalFetched += photos.length;
 
         iterationDetails.push({
-          iteration: iteration + 1,
+          iteration: pageNumber,
           url,
           skip,
           take: PHOTO_MAX_PAGE_SIZE,
@@ -559,11 +641,18 @@ export class RecNetService extends EventEmitter {
 
       // Fetch and save bulk account and room data (from photos + any existing feed)
       try {
-        this.updateProgress(
-          'Fetching account, room, and event data...',
+        this.updateSourceProgress(
+          'metadata',
+          'user-photos',
+          'Collecting related account, room, and event data...',
           0,
           0,
-          0
+          0,
+          {
+            pageLabel: 'Related data',
+            recentActivity:
+              'Collecting related account, room, and event data for user photos...',
+          }
         );
 
         let combinedForMetadata: Photo[] = [...normalizedAll];
@@ -584,7 +673,8 @@ export class RecNetService extends EventEmitter {
           accountId,
           combinedForMetadata,
           token,
-          { forceAccountsRefresh, forceRoomsRefresh, forceEventsRefresh }
+          { forceAccountsRefresh, forceRoomsRefresh, forceEventsRefresh },
+          'user-photos'
         );
         console.log(
           `Fetched ${bulkData.accountsFetched} accounts, ${bulkData.roomsFetched} rooms, and ${bulkData.eventsFetched} events`
@@ -638,7 +728,17 @@ export class RecNetService extends EventEmitter {
 
     try {
       this.resetProgressIssueState();
-      this.updateProgress('Downloading user feed data...', 0, 0, 0);
+      this.updateSourceProgress(
+        'metadata',
+        'user-feed',
+        'Collecting user feed metadata...',
+        0,
+        0,
+        0,
+        {
+          recentActivity: 'Preparing to collect user feed metadata...',
+        }
+      );
 
       const accountDir = path.join(this.settings.outputRoot, accountId);
       console.log(`Creating account directory for feed: ${accountDir}`);
@@ -740,10 +840,19 @@ export class RecNetService extends EventEmitter {
           throw this.createOperationCancelledError();
         }
 
-        this.updateProgress(
-          `Fetching feed page ${iteration + 1}...`,
+        const pageNumber = iteration + 1;
+        const pageLabel = `Page ${pageNumber}`;
+        this.updateSourceProgress(
+          'metadata',
+          'user-feed',
+          'Collecting user feed metadata...',
           iteration,
-          0 // Total unknown since we loop until done
+          0,
+          undefined,
+          {
+            pageLabel,
+            recentActivity: `Checking ${pageLabel.toLowerCase()} for user feed...`,
+          }
         );
 
         const sinceParam = sinceTime.toISOString();
@@ -752,12 +861,20 @@ export class RecNetService extends EventEmitter {
         )}?skip=${skip}&take=${PHOTO_MAX_PAGE_SIZE}&since=${encodeURIComponent(sinceParam)}`;
 
         const photos = this.normalizePhotos(
-          await this.photosController.fetchFeedPhotos(
-            accountId,
-            { skip, take: PHOTO_MAX_PAGE_SIZE, since: sinceParam },
-            token,
-            { signal: operation.controller.signal }
-          )
+          await this.runMetadataRequestWithRetry({
+            label: `user feed page ${pageNumber}`,
+            source: 'user-feed',
+            operationRef: operation,
+            pageLabel,
+            recentActivity: `Collected ${pageLabel.toLowerCase()} for user feed metadata.`,
+            operation: () =>
+              this.photosController.fetchFeedPhotos(
+                accountId,
+                { skip, take: PHOTO_MAX_PAGE_SIZE, since: sinceParam },
+                token,
+                { signal: operation.controller.signal }
+              ),
+          })
         );
         if (!Array.isArray(photos)) {
           throw new Error('Unexpected response format: expected array');
@@ -799,7 +916,7 @@ export class RecNetService extends EventEmitter {
         totalFetched += photos.length;
 
         iterationDetails.push({
-          iteration: iteration + 1,
+          iteration: pageNumber,
           url,
           skip,
           take: PHOTO_MAX_PAGE_SIZE,
@@ -837,11 +954,18 @@ export class RecNetService extends EventEmitter {
 
       // Fetch and save bulk account and room data (feed + any existing photos)
       try {
-        this.updateProgress(
-          'Fetching feed account, room, and event data...',
+        this.updateSourceProgress(
+          'metadata',
+          'user-feed',
+          'Collecting related account, room, and event data...',
           0,
           0,
-          0
+          0,
+          {
+            pageLabel: 'Related data',
+            recentActivity:
+              'Collecting related account, room, and event data for user feed...',
+          }
         );
 
         let combinedForMetadata: Photo[] = [...normalizedFeed];
@@ -865,7 +989,8 @@ export class RecNetService extends EventEmitter {
           accountId,
           combinedForMetadata,
           token,
-          { forceAccountsRefresh, forceRoomsRefresh, forceEventsRefresh }
+          { forceAccountsRefresh, forceRoomsRefresh, forceEventsRefresh },
+          'user-feed'
         );
         console.log(
           `Fetched (feed) ${bulkData.accountsFetched} accounts, ${bulkData.roomsFetched} rooms, and ${bulkData.eventsFetched} events`
@@ -909,7 +1034,14 @@ export class RecNetService extends EventEmitter {
 
     try {
       this.resetProgressIssueState();
-      this.updateProgress('Downloading user photos...', 0, 0, 0);
+      this.updateSourceProgress(
+        'download',
+        'user-photos',
+        'Downloading user photos...',
+        0,
+        0,
+        0
+      );
       const accountDir = path.join(this.settings.outputRoot, accountId);
       const jsonPath = path.join(accountDir, `${accountId}_photos.json`);
 
@@ -957,11 +1089,16 @@ export class RecNetService extends EventEmitter {
         console.log(
           `Skipping photo downloads: limit ${maxPhotosToDownload} reached by existing files (${existingPhotoFiles})`
         );
-        this.updateProgress(
+        this.updateSourceProgress(
+          'download',
+          'user-photos',
           'Download limit reached for photos',
           totalPhotos,
           totalPhotos,
-          100
+          100,
+          {
+            recentActivity: 'Everything in user photos is already on disk for this run.',
+          }
         );
         this.setOperationComplete();
         return {
@@ -1001,7 +1138,14 @@ export class RecNetService extends EventEmitter {
       let recoveredAfterRetry = 0;
       let processedCount = 0;
 
-      this.updateProgress('Downloading user photos...', 0, totalPhotos, 0);
+      this.updateSourceProgress(
+        'download',
+        'user-photos',
+        'Downloading user photos...',
+        0,
+        totalPhotos,
+        0
+      );
 
       let delay = 0;
       const promises: Array<Promise<DownloadResultItem>> = [];
@@ -1041,6 +1185,10 @@ export class RecNetService extends EventEmitter {
                   slotWaitMs,
                 });
                 try {
+                  this.setDownloadItemActivity(
+                    'user-photos',
+                    imageName || photoId || `image ${scheduledIndex}`
+                  );
                   result = await this.downloadImage(
                     photo,
                     photosDir,
@@ -1091,12 +1239,15 @@ export class RecNetService extends EventEmitter {
                   });
                   semaphore.release();
                   if (this.currentOperation === operation) {
-                    this.updateProgress(
+                    processedCount++;
+                    this.setDownloadResultActivity('user-photos', result);
+                    this.updateSourceProgress(
+                      'download',
+                      'user-photos',
                       'Downloading user photos...',
                       processedCount,
                       totalPhotos
                     );
-                    processedCount++;
                   }
                 }
               } catch (error) {
@@ -1158,7 +1309,14 @@ export class RecNetService extends EventEmitter {
 
     try {
       this.resetProgressIssueState();
-      this.updateProgress('Downloading feed photos...', 0, 0, 0);
+      this.updateSourceProgress(
+        'download',
+        'user-feed',
+        'Downloading feed photos...',
+        0,
+        0,
+        0
+      );
       const accountDir = path.join(this.settings.outputRoot, accountId);
       const feedJsonPath = path.join(accountDir, `${accountId}_feed.json`);
 
@@ -1209,11 +1367,16 @@ export class RecNetService extends EventEmitter {
         console.log(
           `Skipping feed photo downloads: limit ${maxPhotosToDownload} reached by existing files (${existingFeedFiles})`
         );
-        this.updateProgress(
+        this.updateSourceProgress(
+          'download',
+          'user-feed',
           'Download limit reached for feed photos',
           totalPhotos,
           totalPhotos,
-          100
+          100,
+          {
+            recentActivity: 'Everything in user feed is already on disk for this run.',
+          }
         );
         this.setOperationComplete();
         return {
@@ -1253,7 +1416,14 @@ export class RecNetService extends EventEmitter {
       let recoveredAfterRetry = 0;
       let processedCount = 0;
 
-      this.updateProgress('Downloading feed photos...', 0, totalPhotos, 0);
+      this.updateSourceProgress(
+        'download',
+        'user-feed',
+        'Downloading feed photos...',
+        0,
+        totalPhotos,
+        0
+      );
 
       let delay = 0;
       const promises: Array<Promise<DownloadResultItem>> = [];
@@ -1293,6 +1463,10 @@ export class RecNetService extends EventEmitter {
                   slotWaitMs,
                 });
                 try {
+                  this.setDownloadItemActivity(
+                    'user-feed',
+                    imageName || photoId || `image ${scheduledIndex}`
+                  );
                   result = await this.downloadImage(
                     photo,
                     photosDir,
@@ -1343,12 +1517,15 @@ export class RecNetService extends EventEmitter {
                   });
                   semaphore.release();
                   if (this.currentOperation === operation) {
-                    this.updateProgress(
+                    processedCount++;
+                    this.setDownloadResultActivity('user-feed', result);
+                    this.updateSourceProgress(
+                      'download',
+                      'user-feed',
                       'Downloading feed photos...',
                       processedCount,
                       totalPhotos
                     );
-                    processedCount++;
                   }
                 }
               } catch (error) {
@@ -1453,6 +1630,102 @@ export class RecNetService extends EventEmitter {
     };
   }
 
+  async collectProfileHistoryManifest(
+    accountId: string,
+    token: string
+  ): Promise<ProfileHistoryCollectionResult> {
+    await this.ensureSettingsLoaded();
+    const operation = this.startOperation();
+
+    try {
+      this.resetProgressIssueState();
+      this.updateSourceProgress(
+        'metadata',
+        'profile-history',
+        'Collecting profile picture history metadata...',
+        0,
+        0,
+        0,
+        {
+          recentActivity:
+            'Preparing to collect profile picture history metadata...',
+        }
+      );
+
+      const cleanedToken = token.trim();
+      if (!cleanedToken) {
+        throw new Error(
+          'Profile picture history requires a valid access token.'
+        );
+      }
+
+      const accountDir = path.join(this.settings.outputRoot, accountId);
+      await fs.ensureDir(accountDir);
+
+      const manifestPath = path.join(
+        accountDir,
+        `${accountId}_profile_history.json`
+      );
+      let existingPhotos = 0;
+
+      if (await fs.pathExists(manifestPath)) {
+        try {
+          const existingPayload = (await fs.readJson(
+            manifestPath
+          )) as ProfileHistoryImageDto[];
+          existingPhotos = this.normalizeProfileHistoryPhotos(
+            existingPayload,
+            accountId
+          ).length;
+        } catch (error) {
+          console.log(
+            `Warning: Failed to read existing profile history manifest: ${(error as Error).message}`
+          );
+        }
+      }
+
+      const historyPayload = await this.runMetadataRequestWithRetry({
+        label: 'profile picture history manifest',
+        source: 'profile-history',
+        operationRef: operation,
+        pageLabel: 'Manifest',
+        recentActivity: 'Collected profile picture history manifest.',
+        operation: () =>
+          this.photosController.fetchProfilePhotoHistory(cleanedToken, {
+            signal: operation.controller.signal,
+          }),
+      });
+
+      if (operation.cancelled) {
+        throw this.createOperationCancelledError();
+      }
+
+      await fs.writeJson(manifestPath, historyPayload, { spaces: 2 });
+
+      const totalPhotos = this.normalizeProfileHistoryPhotos(
+        historyPayload,
+        accountId
+      ).length;
+
+      this.setOperationComplete();
+
+      return {
+        accountId,
+        saved: manifestPath,
+        existingPhotos,
+        totalNewPhotosAdded: Math.max(0, totalPhotos - existingPhotos),
+        totalPhotos,
+      };
+    } catch (error) {
+      if (!this.isOperationCancelledError(error)) {
+        this.setOperationFailed((error as Error).message);
+      }
+      throw error;
+    } finally {
+      this.finishOperation(operation);
+    }
+  }
+
   async downloadProfileHistory(
     accountId: string,
     token: string
@@ -1465,23 +1738,20 @@ export class RecNetService extends EventEmitter {
 
     try {
       this.resetProgressIssueState();
-      this.updateProgress('Downloading profile picture history...', 0, 0, 0);
+      this.updateSourceProgress(
+        'download',
+        'profile-history',
+        'Downloading profile picture history...',
+        0,
+        0,
+        0
+      );
 
       const cleanedToken = token.trim();
       if (!cleanedToken) {
         throw new Error(
           'Profile picture history requires a valid access token.'
         );
-      }
-
-      const requestOptions = { signal: operation.controller.signal };
-      const historyPayload = await this.photosController.fetchProfilePhotoHistory(
-        cleanedToken,
-        requestOptions
-      );
-
-      if (operation.cancelled) {
-        throw this.createOperationCancelledError();
       }
 
       const accountDir = path.join(this.settings.outputRoot, accountId);
@@ -1491,11 +1761,18 @@ export class RecNetService extends EventEmitter {
         accountDir,
         `${accountId}_profile_history.json`
       );
-      await fs.writeJson(manifestPath, historyPayload, { spaces: 2 });
+      if (!(await fs.pathExists(manifestPath))) {
+        throw new Error(
+          'Profile picture history metadata not collected. Run metadata collection first.'
+        );
+      }
 
       const profileHistoryDir = path.join(accountDir, 'profile-history');
       await fs.ensureDir(profileHistoryDir);
 
+      const historyPayload = (await fs.readJson(
+        manifestPath
+      )) as ProfileHistoryImageDto[];
       const profilePhotos = this.normalizeProfileHistoryPhotos(
         historyPayload,
         accountId
@@ -1511,11 +1788,17 @@ export class RecNetService extends EventEmitter {
         (maxPhotosToDownload || 0) - existingFiles;
 
       if (hasDownloadLimit && remainingDownloadSlots <= 0) {
-        this.updateProgress(
+        this.updateSourceProgress(
+          'download',
+          'profile-history',
           'Download limit reached for profile picture history',
           totalPhotos,
           totalPhotos,
-          100
+          100,
+          {
+            recentActivity:
+              'Everything in profile picture history is already on disk for this run.',
+          }
         );
         this.setOperationComplete();
         return {
@@ -1570,7 +1853,9 @@ export class RecNetService extends EventEmitter {
       let recoveredAfterRetry = 0;
       let processedCount = 0;
 
-      this.updateProgress(
+      this.updateSourceProgress(
+        'download',
+        'profile-history',
         'Downloading profile picture history...',
         0,
         totalPhotos,
@@ -1619,6 +1904,10 @@ export class RecNetService extends EventEmitter {
                 });
 
                 try {
+                  this.setDownloadItemActivity(
+                    'profile-history',
+                    imageName || photoId || `image ${scheduledIndex}`
+                  );
                   result = await this.downloadProfileHistoryImage(
                     photo,
                     profileHistoryDir,
@@ -1660,12 +1949,15 @@ export class RecNetService extends EventEmitter {
                   });
                   semaphore.release();
                   if (this.currentOperation === operation) {
-                    this.updateProgress(
+                    processedCount++;
+                    this.setDownloadResultActivity('profile-history', result);
+                    this.updateSourceProgress(
+                      'download',
+                      'profile-history',
                       'Downloading profile picture history...',
                       processedCount,
                       totalPhotos
                     );
-                    processedCount++;
                   }
                 }
               } catch (error) {
@@ -1743,6 +2035,7 @@ export class RecNetService extends EventEmitter {
     if (operation?.cancelled || this.currentOperation?.cancelled) {
       return {
         photoId,
+        imageName,
         status: 'cancelled',
       };
     }
@@ -1754,6 +2047,7 @@ export class RecNetService extends EventEmitter {
     if (await fs.pathExists(photoPath)) {
       return {
         photoId,
+        imageName,
         status: isFeed ? 'already_exists_in_feed' : 'already_exists_in_photos',
         path: photoPath,
       };
@@ -1765,9 +2059,17 @@ export class RecNetService extends EventEmitter {
       `${photoId}.jpg`
     );
     if (await fs.pathExists(otherPhotoPath)) {
-      await fs.copy(otherPhotoPath, photoPath);
+      try {
+        await fs.copy(otherPhotoPath, photoPath);
+      } catch (error) {
+        if (this.isOutOfDiskSpaceError(error)) {
+          this.abortOperationForDiskFull(imageName, operation);
+        }
+        throw error;
+      }
       return {
         photoId,
+        imageName,
         status: isFeed ? 'copied_from_photos' : 'copied_from_feed',
         sourcePath: otherPhotoPath,
         destinationPath: photoPath,
@@ -1794,9 +2096,17 @@ export class RecNetService extends EventEmitter {
       const response = attempt.response;
       if (response?.success && response.value) {
         const data = Buffer.from(response.value);
-        await fs.writeFile(photoPath, data);
+        try {
+          await fs.writeFile(photoPath, data);
+        } catch (error) {
+          if (this.isOutOfDiskSpaceError(error)) {
+            this.abortOperationForDiskFull(imageName, operation);
+          }
+          throw error;
+        }
         return {
           photoId,
+          imageName,
           status: 'downloaded',
           size: data.length,
           path: photoPath,
@@ -1808,6 +2118,7 @@ export class RecNetService extends EventEmitter {
       } else if (response) {
         return {
           photoId,
+          imageName,
           status: 'failed',
           statusCode: response.status,
           reason: (response.message || response.error) ?? undefined,
@@ -1822,12 +2133,18 @@ export class RecNetService extends EventEmitter {
       if (error instanceof Error && error.message === 'Operation cancelled') {
         return {
           photoId,
+          imageName,
           status: 'cancelled',
         };
       }
 
+      if (this.isOutOfDiskSpaceError(error)) {
+        this.abortOperationForDiskFull(imageName, operation);
+      }
+
       return {
         photoId,
+        imageName,
         status: 'error',
         error: (error as Error).message,
         url: photoUrl,
@@ -1859,6 +2176,7 @@ export class RecNetService extends EventEmitter {
     if (operation?.cancelled || this.currentOperation?.cancelled) {
       return {
         photoId,
+        imageName,
         status: 'cancelled',
       };
     }
@@ -1867,6 +2185,7 @@ export class RecNetService extends EventEmitter {
     if (await fs.pathExists(photoPath)) {
       return {
         photoId,
+        imageName,
         status: 'already_exists_in_profile_history',
         path: photoPath,
       };
@@ -1886,9 +2205,17 @@ export class RecNetService extends EventEmitter {
 
       if (response?.success && response.value) {
         const data = Buffer.from(response.value);
-        await fs.writeFile(photoPath, data);
+        try {
+          await fs.writeFile(photoPath, data);
+        } catch (error) {
+          if (this.isOutOfDiskSpaceError(error)) {
+            this.abortOperationForDiskFull(imageName, operation);
+          }
+          throw error;
+        }
         return {
           photoId,
+          imageName,
           status: 'downloaded',
           size: data.length,
           path: photoPath,
@@ -1902,6 +2229,7 @@ export class RecNetService extends EventEmitter {
       if (response) {
         return {
           photoId,
+          imageName,
           status: 'failed',
           statusCode: response.status,
           reason: (response.message || response.error) ?? undefined,
@@ -1916,12 +2244,18 @@ export class RecNetService extends EventEmitter {
       if (error instanceof Error && error.message === 'Operation cancelled') {
         return {
           photoId,
+          imageName,
           status: 'cancelled',
         };
       }
 
+      if (this.isOutOfDiskSpaceError(error)) {
+        this.abortOperationForDiskFull(imageName, operation);
+      }
+
       return {
         photoId,
+        imageName,
         status: 'error',
         error: (error as Error).message,
         url: photoUrl,
@@ -2274,6 +2608,7 @@ export class RecNetService extends EventEmitter {
   private createProgressState(overrides: Partial<Progress>): Progress {
     return {
       isRunning: false,
+      phase: 'complete',
       currentStep: 'Ready',
       progress: 0,
       total: 0,
@@ -2283,7 +2618,12 @@ export class RecNetService extends EventEmitter {
       retryAttempts: 0,
       failedItems: 0,
       recoveredAfterRetry: 0,
+      currentSource: undefined,
+      pageLabel: undefined,
+      activeItemLabel: undefined,
+      recentActivity: undefined,
       lastIssue: undefined,
+      confirmation: undefined,
       ...overrides,
     };
   }
@@ -2296,7 +2636,9 @@ export class RecNetService extends EventEmitter {
       retryAttempts: 0,
       failedItems: 0,
       recoveredAfterRetry: 0,
+      recentActivity: undefined,
       lastIssue: undefined,
+      confirmation: undefined,
     });
   }
 
@@ -2334,6 +2676,125 @@ export class RecNetService extends EventEmitter {
       lastIssue: message,
     });
     this.emit('progress-update', this.progress);
+  }
+
+  private updateProgressActivity(
+    recentActivity: string,
+    overrides: Partial<Progress> = {}
+  ): void {
+    if (!this.currentOperation || this.currentOperation.cancelled) {
+      return;
+    }
+
+    this.progress = this.createProgressState({
+      ...this.progress,
+      recentActivity,
+      ...overrides,
+    });
+    this.emit('progress-update', this.progress);
+  }
+
+  private updateSourceProgress(
+    phase: Progress['phase'],
+    source: DownloadSource,
+    step: string,
+    current: number,
+    total: number,
+    progress?: number,
+    overrides: Partial<Progress> = {}
+  ): void {
+    this.updateProgress(step, current, total, progress, {
+      phase,
+      currentSource: source,
+      ...overrides,
+    });
+  }
+
+  private getSourceLabel(source: DownloadSource): string {
+    switch (source) {
+      case 'user-feed':
+        return 'user feed';
+      case 'user-photos':
+        return 'user photos';
+      case 'profile-history':
+        return 'profile picture history';
+      default:
+        return source;
+    }
+  }
+
+  private async runMetadataRequestWithRetry<T>(params: {
+    label: string;
+    source: DownloadSource;
+    operation: () => Promise<T>;
+    operationRef?: CurrentOperation;
+    pageLabel?: string;
+    recentActivity?: string;
+  }): Promise<T> {
+    let attempts = 0;
+    let lastError: Error | undefined;
+
+    while (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
+      if (params.operationRef?.cancelled || this.currentOperation?.cancelled) {
+        throw this.createOperationCancelledError();
+      }
+
+      attempts++;
+
+      try {
+        const result = await params.operation();
+
+        if (attempts > 1) {
+          this.markProgressRecovery(
+            `Recovered ${params.label} after ${attempts - 1} retr${
+              attempts - 1 === 1 ? 'y' : 'ies'
+            }. Metadata collection is continuing.`
+          );
+        }
+
+        if (params.recentActivity) {
+          this.updateProgressActivity(params.recentActivity, {
+            phase: 'metadata',
+            currentSource: params.source,
+            pageLabel: params.pageLabel,
+          });
+        }
+
+        return result;
+      } catch (error) {
+        if (this.isOperationCancelledError(error)) {
+          throw error;
+        }
+
+        lastError = error as Error;
+        const failureReason = lastError.message || 'unknown_error';
+        const issueMessage =
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS
+            ? `Issue collecting ${params.label}: ${failureReason}. Retry ${attempts}/${PHOTO_DOWNLOAD_RETRY_COUNT} will start now.`
+            : `Metadata collection failed for ${params.label}: ${failureReason}.`;
+
+        this.markProgressIssue(
+          attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 'warning' : 'error',
+          issueMessage,
+          {
+            retryIncrement: attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+            failedItemIncrement:
+              attempts >= PHOTO_DOWNLOAD_MAX_ATTEMPTS ? 1 : 0,
+          }
+        );
+
+        if (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
+          await this.delay(PHOTO_DOWNLOAD_RETRY_DELAY_MS, params.operationRef);
+          continue;
+        }
+      }
+    }
+
+    throw new Error(
+      `Failed to collect ${params.label} after ${PHOTO_DOWNLOAD_RETRY_COUNT} retries: ${
+        lastError?.message || 'unknown_error'
+      }`
+    );
   }
 
   private async downloadPhotoWithRetry(
@@ -2514,7 +2975,8 @@ export class RecNetService extends EventEmitter {
     accountId: string,
     photos: Photo[],
     token?: string,
-    options: BulkDataRefreshOptions = {}
+    options: BulkDataRefreshOptions = {},
+    source: DownloadSource = 'user-photos'
   ): Promise<{
     accountsFetched: number;
     roomsFetched: number;
@@ -2531,7 +2993,18 @@ export class RecNetService extends EventEmitter {
         forceEventsRefresh = false,
       } = options;
       const normalizedPhotos = this.normalizePhotos(photos);
-      this.updateProgress('Extracting IDs from photos...', 0, 0, 0);
+      this.updateSourceProgress(
+        'metadata',
+        source,
+        'Collecting related account, room, and event data...',
+        0,
+        0,
+        0,
+        {
+          pageLabel: 'Related data',
+          recentActivity: `Extracting related IDs from ${this.getSourceLabel(source)} metadata...`,
+        }
+      );
 
       // Extract unique IDs
       const { accountIds, roomIds, eventIds } =
@@ -2539,9 +3012,14 @@ export class RecNetService extends EventEmitter {
       const accountIdsArray = Array.from(accountIds);
       const roomIdsArray = Array.from(roomIds);
       const eventIdsArray = Array.from(eventIds);
-      this.updateProgress('Grabbing unique accounts', 0, 0, 0);
-      this.updateProgress('Grabbing unique rooms', 0, 0, 0);
-      this.updateProgress('Grabbing unique events', 0, 0, 0);
+      this.updateProgressActivity(
+        `Found ${accountIdsArray.length} accounts, ${roomIdsArray.length} rooms, and ${eventIdsArray.length} events in ${this.getSourceLabel(source)} metadata.`,
+        {
+          phase: 'metadata',
+          currentSource: source,
+          pageLabel: 'Related data',
+        }
+      );
 
       console.log(
         `Found ${accountIdsArray.length} unique account IDs, ${roomIdsArray.length} unique room IDs, and ${eventIdsArray.length} unique event IDs`
@@ -2565,11 +3043,16 @@ export class RecNetService extends EventEmitter {
 
       // Fetch and save account data
       if (accountIdsArray.length > 0) {
-        this.updateProgress(
+        this.updateSourceProgress(
+          'metadata',
+          source,
           'Checking account cache',
           0,
           accountIdsArray.length,
-          0
+          0,
+          {
+            pageLabel: 'Accounts',
+          }
         );
 
         let cachedAccounts: PlayerResult[] = [];
@@ -2613,25 +3096,45 @@ export class RecNetService extends EventEmitter {
             : accountIdsArray;
 
         if (missingAccountIds.length === 0) {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Using cached account data',
             accountIdsArray.length,
             accountIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Accounts',
+              recentActivity: 'Using cached account data.',
+            }
           );
         } else {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             `Downloading account data (${missingAccountIds.length} missing of ${accountIdsArray.length})...`,
             0,
             accountIdsArray.length,
-            0
+            0,
+            {
+              pageLabel: 'Accounts',
+              recentActivity: `Downloading ${missingAccountIds.length} missing account record(s)...`,
+            }
           );
 
-          const accountsData = await this.accountsController.fetchBulkAccounts(
-            missingAccountIds,
-            token,
-            requestOptions
-          );
+          const accountsData = await this.runMetadataRequestWithRetry({
+            label: 'account metadata',
+            source,
+            operationRef: this.currentOperation ?? undefined,
+            pageLabel: 'Accounts',
+            recentActivity: 'Account metadata downloaded.',
+            operation: () =>
+              this.accountsController.fetchBulkAccounts(
+                missingAccountIds,
+                token,
+                requestOptions
+              ),
+          });
           const normalizedAccounts = Array.isArray(accountsData)
             ? this.normalizeAccounts(accountsData)
             : [];
@@ -2662,18 +3165,33 @@ export class RecNetService extends EventEmitter {
             `Saved ${mergedAccounts.length} accounts to ${accountsJsonPath} (downloaded ${normalizedAccounts.length} new entries)`
           );
 
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Account data updated',
             accountIdsArray.length,
             accountIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Accounts',
+            }
           );
         }
       }
 
       // Fetch and save room data
       if (roomIdsArray.length > 0) {
-        this.updateProgress('Checking rooms cache', 0, roomIdsArray.length, 0);
+        this.updateSourceProgress(
+          'metadata',
+          source,
+          'Checking rooms cache',
+          0,
+          roomIdsArray.length,
+          0,
+          {
+            pageLabel: 'Rooms',
+          }
+        );
 
         let cachedRooms: RoomDto[] = [];
         let cachedRoomIds = new Set<string>();
@@ -2699,24 +3217,44 @@ export class RecNetService extends EventEmitter {
             : roomIdsArray;
 
         if (missingRoomIds.length === 0) {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Using cached room data',
             roomIdsArray.length,
             roomIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Rooms',
+              recentActivity: 'Using cached room data.',
+            }
           );
         } else {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             `Downloading room data (${missingRoomIds.length} missing of ${roomIdsArray.length})...`,
             0,
             roomIdsArray.length,
-            0
+            0,
+            {
+              pageLabel: 'Rooms',
+              recentActivity: `Downloading ${missingRoomIds.length} missing room record(s)...`,
+            }
           );
-          const roomsData = await this.roomsController.fetchBulkRooms(
-            missingRoomIds,
-            token,
-            requestOptions
-          );
+          const roomsData = await this.runMetadataRequestWithRetry({
+            label: 'room metadata',
+            source,
+            operationRef: this.currentOperation ?? undefined,
+            pageLabel: 'Rooms',
+            recentActivity: 'Room metadata downloaded.',
+            operation: () =>
+              this.roomsController.fetchBulkRooms(
+                missingRoomIds,
+                token,
+                requestOptions
+              ),
+          });
           const normalizedRooms = Array.isArray(roomsData)
             ? this.normalizeRooms(roomsData)
             : [];
@@ -2736,22 +3274,32 @@ export class RecNetService extends EventEmitter {
             `Saved ${mergedRooms.length} rooms to ${roomsJsonPath} (downloaded ${normalizedRooms.length} new entries)`
           );
 
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Room data updated',
             roomIdsArray.length,
             roomIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Rooms',
+            }
           );
         }
       }
 
       // Fetch and save event data
       if (eventIdsArray.length > 0) {
-        this.updateProgress(
+        this.updateSourceProgress(
+          'metadata',
+          source,
           'Checking events cache',
           0,
           eventIdsArray.length,
-          0
+          0,
+          {
+            pageLabel: 'Events',
+          }
         );
 
         let cachedEvents: EventDto[] = [];
@@ -2782,24 +3330,44 @@ export class RecNetService extends EventEmitter {
             : eventIdsArray;
 
         if (missingEventIds.length === 0) {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Using cached event data',
             eventIdsArray.length,
             eventIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Events',
+              recentActivity: 'Using cached event data.',
+            }
           );
         } else {
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             `Downloading event data (${missingEventIds.length} missing of ${eventIdsArray.length})...`,
             0,
             eventIdsArray.length,
-            0
+            0,
+            {
+              pageLabel: 'Events',
+              recentActivity: `Downloading ${missingEventIds.length} missing event record(s)...`,
+            }
           );
-          const eventsData = await this.eventsController.fetchBulkEvents(
-            missingEventIds,
-            token,
-            requestOptions
-          );
+          const eventsData = await this.runMetadataRequestWithRetry({
+            label: 'event metadata',
+            source,
+            operationRef: this.currentOperation ?? undefined,
+            pageLabel: 'Events',
+            recentActivity: 'Event metadata downloaded.',
+            operation: () =>
+              this.eventsController.fetchBulkEvents(
+                missingEventIds,
+                token,
+                requestOptions
+              ),
+          });
           const normalizedEvents = Array.isArray(eventsData)
             ? this.normalizeEvents(eventsData)
             : [];
@@ -2819,11 +3387,16 @@ export class RecNetService extends EventEmitter {
             `Saved ${mergedEvents.length} events to ${eventsJsonPath} (downloaded ${normalizedEvents.length} new entries)`
           );
 
-          this.updateProgress(
+          this.updateSourceProgress(
+            'metadata',
+            source,
             'Event data updated',
             eventIdsArray.length,
             eventIdsArray.length,
-            100
+            100,
+            {
+              pageLabel: 'Events',
+            }
           );
         }
       }
@@ -2835,6 +3408,217 @@ export class RecNetService extends EventEmitter {
       );
       throw error;
     }
+  }
+
+  async buildDownloadPreflightSummary(
+    accountId: string,
+    selection: DownloadSourceSelection
+  ): Promise<DownloadPreflightSummary> {
+    await this.ensureSettingsLoaded();
+
+    const sourceSummaries = await Promise.all(
+      getSelectedDownloadSources(selection).map(source =>
+        this.buildPreflightSourceSummary(accountId, source)
+      )
+    );
+
+    return {
+      accountId,
+      sourceSummaries,
+      totalImages: sourceSummaries.reduce(
+        (sum, summary) => sum + summary.totalImages,
+        0
+      ),
+      totalAlreadyOnDisk: sourceSummaries.reduce(
+        (sum, summary) => sum + summary.alreadyOnDisk,
+        0
+      ),
+      totalRemainingToDownload: sourceSummaries.reduce(
+        (sum, summary) => sum + summary.remainingToDownload,
+        0
+      ),
+    };
+  }
+
+  private async buildPreflightSourceSummary(
+    accountId: string,
+    source: DownloadSource
+  ): Promise<DownloadPreflightSourceSummary> {
+    const accountDir = path.join(this.settings.outputRoot, accountId);
+
+    if (source === 'user-photos') {
+      const metadataPath = path.join(accountDir, `${accountId}_photos.json`);
+      const photosDir = path.join(accountDir, 'photos');
+      const feedDir = path.join(accountDir, 'feed');
+      const metadata = await this.readPhotoMetadataFile(metadataPath);
+      const photosInfo = await this.readImageDirectoryInfo(photosDir);
+      const feedInfo = await this.readImageDirectoryInfo(feedDir);
+      const isOnDisk = (photo: Photo): boolean => {
+        const photoId = this.normalizeId(photo.Id);
+        return !!photoId && (photosInfo.ids.has(photoId) || feedInfo.ids.has(photoId));
+      };
+      const alreadyOnDisk = metadata.filter(isOnDisk).length;
+      const remainingToDownload = Math.max(0, metadata.length - alreadyOnDisk);
+      const privateImagesToDownload = metadata.filter(
+        photo => photo.Accessibility === 0 && !isOnDisk(photo)
+      ).length;
+
+      return {
+        source,
+        label: 'User Photos',
+        totalImages: metadata.length,
+        alreadyOnDisk,
+        remainingToDownload,
+        privateImagesToDownload,
+        metadataPath,
+        downloadDirectory: photosDir,
+      };
+    }
+
+    if (source === 'user-feed') {
+      const metadataPath = path.join(accountDir, `${accountId}_feed.json`);
+      const feedDir = path.join(accountDir, 'feed');
+      const photosDir = path.join(accountDir, 'photos');
+      const metadata = await this.readPhotoMetadataFile(metadataPath);
+      const feedInfo = await this.readImageDirectoryInfo(feedDir);
+      const photosInfo = await this.readImageDirectoryInfo(photosDir);
+      const isOnDisk = (photo: Photo): boolean => {
+        const photoId = this.normalizeId(photo.Id);
+        return !!photoId && (feedInfo.ids.has(photoId) || photosInfo.ids.has(photoId));
+      };
+      const alreadyOnDisk = metadata.filter(isOnDisk).length;
+      const remainingToDownload = Math.max(0, metadata.length - alreadyOnDisk);
+      const privateImagesToDownload = metadata.filter(
+        photo => photo.Accessibility === 0 && !isOnDisk(photo)
+      ).length;
+
+      return {
+        source,
+        label: 'User Feed',
+        totalImages: metadata.length,
+        alreadyOnDisk,
+        remainingToDownload,
+        privateImagesToDownload,
+        metadataPath,
+        downloadDirectory: feedDir,
+      };
+    }
+
+    const metadataPath = path.join(accountDir, `${accountId}_profile_history.json`);
+    const profileHistoryDir = path.join(accountDir, 'profile-history');
+    const manifestPayload = await this.readProfileHistoryManifest(metadataPath);
+    const metadata = this.normalizeProfileHistoryPhotos(manifestPayload, accountId);
+    const directoryInfo = await this.readImageDirectoryInfo(profileHistoryDir);
+    const alreadyOnDisk = metadata.filter(photo => {
+      const photoId = this.normalizeId(photo.Id);
+      return !!photoId && directoryInfo.ids.has(photoId);
+    }).length;
+    const remainingToDownload = Math.max(0, metadata.length - alreadyOnDisk);
+
+    return {
+      source,
+      label: 'Profile Picture History',
+      totalImages: metadata.length,
+      alreadyOnDisk,
+      remainingToDownload,
+      metadataPath,
+      downloadDirectory: profileHistoryDir,
+    };
+  }
+
+  private async readPhotoMetadataFile(metadataPath: string): Promise<Photo[]> {
+    if (!(await fs.pathExists(metadataPath))) {
+      return [];
+    }
+
+    const payload = (await fs.readJson(metadataPath)) as ImageDto[];
+    return Array.isArray(payload) ? this.normalizePhotos(payload) : [];
+  }
+
+  private async readProfileHistoryManifest(
+    metadataPath: string
+  ): Promise<ProfileHistoryImageDto[]> {
+    if (!(await fs.pathExists(metadataPath))) {
+      return [];
+    }
+
+    const payload = (await fs.readJson(metadataPath)) as ProfileHistoryImageDto[];
+    return Array.isArray(payload) ? payload : [];
+  }
+
+  private async readImageDirectoryInfo(directoryPath: string): Promise<{
+    ids: Set<string>;
+  }> {
+    const ids = new Set<string>();
+
+    if (!(await fs.pathExists(directoryPath))) {
+      return { ids };
+    }
+
+    const entries = await fs.readdir(directoryPath);
+    for (const entry of entries) {
+      if (!entry.toLowerCase().endsWith('.jpg')) {
+        continue;
+      }
+
+      const id = path.parse(entry).name;
+      if (id) {
+        ids.add(id);
+      }
+    }
+
+    return { ids };
+  }
+
+  private setDownloadItemActivity(
+    source: DownloadSource,
+    imageLabel: string
+  ): void {
+    this.updateProgressActivity(`Downloading ${imageLabel}...`, {
+      phase: 'download',
+      currentSource: source,
+      activeItemLabel: imageLabel,
+    });
+  }
+
+  private setDownloadResultActivity(
+    source: DownloadSource,
+    result?: DownloadResultItem
+  ): void {
+    if (!result) {
+      return;
+    }
+
+    const imageLabel = result.imageName || result.photoId || 'image';
+    let recentActivity: string | undefined;
+
+    if (result.status === 'downloaded') {
+      recentActivity = `Downloaded ${imageLabel}.`;
+    } else if (
+      result.status &&
+      (result.status.startsWith('already_exists') ||
+        result.status.startsWith('copied_from'))
+    ) {
+      recentActivity = `Grabbed from disk: ${imageLabel}.`;
+    } else if (result.status === 'failed' || result.status === 'error') {
+      const retryCount = Math.max(0, (result.attempts || 1) - 1);
+      recentActivity =
+        retryCount > 0
+          ? `Could not download ${imageLabel} after ${retryCount} retr${
+              retryCount === 1 ? 'y' : 'ies'
+            }.`
+          : `Could not download ${imageLabel}.`;
+    }
+
+    if (!recentActivity) {
+      return;
+    }
+
+    this.updateProgressActivity(recentActivity, {
+      phase: 'download',
+      currentSource: source,
+      activeItemLabel: imageLabel,
+    });
   }
 
   async lookupAccountById(accountId: string): Promise<AccountInfo> {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1036,6 +1036,7 @@ function App() {
                 onClose={() => setShowProgressPanel(false)}
                 onOpenOperationResults={openOperationResults}
                 onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+                onCancelDownload={handleCancelDownload}
                 onConfirmDownload={handleConfirmDownload}
                 onSkipDownload={handleSkipDownload}
                 onRetryDownload={handleRetryDownload}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import {
   RecNetSettings,
   Progress,
   BulkDataRefreshOptions,
+  DownloadPreflightSummary,
   DownloadResult,
   UserFacingIncident,
 } from '../shared/types';
@@ -39,7 +40,15 @@ interface DownloadRequestState {
   refreshOptions: BulkDataRefreshOptions;
 }
 
+interface PendingDownloadPreflight {
+  accountId: string;
+  request: DownloadRequestState;
+  summary: DownloadPreflightSummary;
+}
+
 const EMPTY_DOWNLOAD_STEP = 'Nothing to download';
+const CLEAN_DOWNLOAD_FOLLOW_UP =
+  'If you take more photos in Rec Room, come back and run this download again. The app will only grab anything new.';
 
 function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
@@ -51,6 +60,7 @@ function App() {
 
   const [progress, setProgress] = useState<Progress>({
     isRunning: false,
+    phase: 'complete',
     currentStep: 'Ready',
     progress: 0,
     total: 0,
@@ -92,14 +102,14 @@ function App() {
       timestamp: string;
     }>
   >([]);
-  const [downloadDraft, setDownloadDraft] = useState<DownloadRequestState | null>(
-    null
-  );
+  const [downloadDraft, setDownloadDraft] =
+    useState<DownloadRequestState | null>(null);
+  const [pendingPreflight, setPendingPreflight] =
+    useState<PendingDownloadPreflight | null>(null);
   const [lastDownloadRequest, setLastDownloadRequest] =
     useState<DownloadRequestState | null>(null);
-  const [activeIncident, setActiveIncident] = useState<UserFacingIncident | null>(
-    null
-  );
+  const [activeIncident, setActiveIncident] =
+    useState<UserFacingIncident | null>(null);
 
   useEffect(() => {
     loadSettings();
@@ -125,8 +135,7 @@ function App() {
         setSettings(loadedSettings);
       }
     } catch (error) {
-      const msg =
-        error instanceof Error ? error.message : 'Unknown error';
+      const msg = error instanceof Error ? error.message : 'Unknown error';
       addLog(`Failed to load settings: ${msg}`, 'error');
       setActiveIncident(createUserIncident('settings', msg));
     }
@@ -136,7 +145,10 @@ function App() {
     if (window.electronAPI) {
       window.electronAPI.onProgress((event, progressData) => {
         setProgress(progressData);
-        if (progressData.statusLevel !== 'info' || progressData.issueCount > 0) {
+        if (
+          progressData.statusLevel !== 'info' ||
+          progressData.issueCount > 0
+        ) {
           setShowProgressPanel(true);
         }
       });
@@ -149,12 +161,8 @@ function App() {
         await window.electronAPI.loadPhotos(accountId);
       }
     } catch (error) {
-      const msg =
-        error instanceof Error ? error.message : 'Unknown error';
-      addLog(
-        `Failed to load photos for account ${accountId}: ${msg}`,
-        'error'
-      );
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      addLog(`Failed to load photos for account ${accountId}: ${msg}`, 'error');
       setActiveIncident(createUserIncident('photos', msg));
     }
   };
@@ -191,26 +199,23 @@ function App() {
     setActiveIncident(prev => (prev?.source === 'photos' ? null : prev));
   }, []);
 
-  const handleOpenPathInExplorer = useCallback(
-    async (folderPath: string) => {
-      if (!window.electronAPI?.openPathInExplorer) {
-        return;
-      }
-      const r = await window.electronAPI.openPathInExplorer(folderPath);
-      if (!r.success) {
-        const timestamp = new Date().toLocaleTimeString();
-        setLogs(prev => [
-          ...prev.slice(-99),
-          {
-            message: r.error ?? 'Could not open folder',
-            type: 'error' as const,
-            timestamp,
-          },
-        ]);
-      }
-    },
-    []
-  );
+  const handleOpenPathInExplorer = useCallback(async (folderPath: string) => {
+    if (!window.electronAPI?.openPathInExplorer) {
+      return;
+    }
+    const r = await window.electronAPI.openPathInExplorer(folderPath);
+    if (!r.success) {
+      const timestamp = new Date().toLocaleTimeString();
+      setLogs(prev => [
+        ...prev.slice(-99),
+        {
+          message: r.error ?? 'Could not open folder',
+          type: 'error' as const,
+          timestamp,
+        },
+      ]);
+    }
+  }, []);
 
   const addResult = useCallback(
     (operation: string, data: unknown, type: 'success' | 'error') => {
@@ -232,8 +237,14 @@ function App() {
       directoryLabel?: string;
       manifestPath?: string;
     }) => {
-      const { directoryLabel, directoryPath, label, manifestPath, operation, result } =
-        params;
+      const {
+        directoryLabel,
+        directoryPath,
+        label,
+        manifestPath,
+        operation,
+        result,
+      } = params;
       const stats = result.downloadStats;
 
       addLog(
@@ -263,6 +274,59 @@ function App() {
       addResult(operation, result, 'success');
     },
     [addLog, addResult]
+  );
+
+  const setCleanCompletionProgress = useCallback(
+    (currentStep: string, recentActivity = CLEAN_DOWNLOAD_FOLLOW_UP) => {
+      setProgress(prev => ({
+        ...prev,
+        isRunning: false,
+        phase: 'complete',
+        currentStep,
+        progress: 100,
+        total: 0,
+        current: 0,
+        statusLevel: 'info',
+        issueCount: 0,
+        retryAttempts: 0,
+        failedItems: 0,
+        recoveredAfterRetry: 0,
+        currentSource: undefined,
+        pageLabel: undefined,
+        activeItemLabel: undefined,
+        recentActivity,
+        lastIssue: undefined,
+        confirmation: undefined,
+      }));
+    },
+    []
+  );
+
+  const setConfirmationProgress = useCallback(
+    (summary: DownloadPreflightSummary) => {
+      setProgress(prev => ({
+        ...prev,
+        isRunning: false,
+        phase: 'confirm',
+        currentStep:
+          'Metadata is ready. Review this download before continuing.',
+        progress: 100,
+        total: summary.totalRemainingToDownload,
+        current: 0,
+        statusLevel: 'info',
+        issueCount: 0,
+        retryAttempts: 0,
+        failedItems: 0,
+        recoveredAfterRetry: 0,
+        currentSource: undefined,
+        pageLabel: undefined,
+        activeItemLabel: undefined,
+        recentActivity: undefined,
+        lastIssue: undefined,
+        confirmation: summary,
+      }));
+    },
+    []
   );
 
   const clearLogs = () => {
@@ -297,9 +361,11 @@ function App() {
     const previousProgress = previousProgressRef.current;
 
     if (previousProgress) {
-      getDownloadProgressLogEntries(previousProgress, progress).forEach(entry => {
-        addLog(entry.message, entry.type);
-      });
+      getDownloadProgressLogEntries(previousProgress, progress).forEach(
+        entry => {
+          addLog(entry.message, entry.type);
+        }
+      );
 
       const progressChanged =
         progress.issueCount !== previousProgress.issueCount ||
@@ -319,6 +385,10 @@ function App() {
         const incident = buildDownloadProgressIncident(progress);
         if (incident) {
           setActiveIncident(incident);
+        } else {
+          setActiveIncident(prev =>
+            prev?.source === 'download' ? null : prev
+          );
         }
       }
     }
@@ -339,6 +409,7 @@ function App() {
     }
 
     setActiveIncident(null);
+    setPendingPreflight(null);
 
     const {
       forceAccountsRefresh = false,
@@ -360,10 +431,11 @@ function App() {
     setLastDownloadRequest(requestState);
 
     setIsDownloading(true);
-    addLog(`Starting download for username: ${username}`, 'info');
+    addLog(`Starting metadata collection for username: ${username}`, 'info');
     setProgress({
       isRunning: true,
-      currentStep: 'Starting download...',
+      phase: 'metadata',
+      currentStep: 'Starting metadata collection...',
       progress: 0,
       total: 0,
       current: 0,
@@ -372,11 +444,14 @@ function App() {
       retryAttempts: 0,
       failedItems: 0,
       recoveredAfterRetry: 0,
+      currentSource: undefined,
+      pageLabel: undefined,
+      activeItemLabel: undefined,
+      recentActivity: 'Preparing download metadata...',
+      confirmation: undefined,
     });
 
     try {
-      let encounteredEmptySource = false;
-
       // Update settings with new file path
       if (window.electronAPI) {
         await window.electronAPI.updateSettings({ outputRoot: filePath });
@@ -389,10 +464,7 @@ function App() {
           username,
           token.trim() || undefined
         );
-        if (
-          !searchResult.success ||
-          !searchResult.data
-        ) {
+        if (!searchResult.success || !searchResult.data) {
           throw new Error('Account not found');
         }
 
@@ -430,14 +502,15 @@ function App() {
         for (const source of selectedSources) {
           if (source === 'user-feed') {
             addLog('Collecting feed photos metadata...', 'info');
-            const collectFeedResult = await window.electronAPI.collectFeedPhotos({
-              accountId,
-              token: token.trim() || undefined,
-              incremental: true,
-              forceAccountsRefresh,
-              forceRoomsRefresh,
-              forceEventsRefresh,
-            });
+            const collectFeedResult =
+              await window.electronAPI.collectFeedPhotos({
+                accountId,
+                token: token.trim() || undefined,
+                incremental: true,
+                forceAccountsRefresh,
+                forceRoomsRefresh,
+                forceEventsRefresh,
+              });
 
             if (!collectFeedResult.success) {
               throw new Error(
@@ -446,57 +519,10 @@ function App() {
             }
 
             const totalFeedPhotos = collectFeedResult.data?.totalPhotos || 0;
-            if (totalFeedPhotos === 0) {
-              const emptyMessage =
-                'This account does not have any feed photos to download.';
-              addLog(emptyMessage, 'warning');
-              setShowProgressPanel(true);
-              setProgress(prev => ({
-                ...prev,
-                isRunning: false,
-                currentStep: EMPTY_DOWNLOAD_STEP,
-                progress: 100,
-                total: 0,
-                current: 0,
-                statusLevel: 'warning',
-                issueCount: 0,
-                retryAttempts: 0,
-                failedItems: 0,
-                recoveredAfterRetry: 0,
-                lastIssue: emptyMessage,
-              }));
-              setActiveIncident(
-                createUserIncident('download', emptyMessage, {
-                  severity: 'warning',
-                })
-              );
-              encounteredEmptySource = true;
-              continue;
-            }
-
-            addLog(`Collected ${totalFeedPhotos} feed photos metadata`, 'success');
-
-            addLog('Downloading feed photos...', 'info');
-            const downloadFeedResult =
-              await window.electronAPI.downloadFeedPhotos({
-                accountId,
-                token: token.trim() || undefined,
-              });
-
-            if (!downloadFeedResult.success || !downloadFeedResult.data) {
-              throw new Error(
-                downloadFeedResult.error || 'Failed to download feed photos'
-              );
-            }
-
-            reportDownloadResult({
-              operation: 'User Feed Download',
-              label: 'Feed download',
-              result: downloadFeedResult.data,
-              directoryPath: downloadFeedResult.data.feedPhotosDirectory,
-              directoryLabel: 'Feed photos saved to',
-            });
-            loadPhotosForAccount(accountId);
+            addLog(
+              `Collected feed metadata for ${totalFeedPhotos} image(s).`,
+              'success'
+            );
             continue;
           }
 
@@ -517,56 +543,10 @@ function App() {
             }
 
             const totalPhotos = collectPhotosResult.data?.totalPhotos || 0;
-            if (totalPhotos === 0) {
-              const emptyMessage =
-                'This account does not have any user photos to download.';
-              addLog(emptyMessage, 'warning');
-              setShowProgressPanel(true);
-              setProgress(prev => ({
-                ...prev,
-                isRunning: false,
-                currentStep: EMPTY_DOWNLOAD_STEP,
-                progress: 100,
-                total: 0,
-                current: 0,
-                statusLevel: 'warning',
-                issueCount: 0,
-                retryAttempts: 0,
-                failedItems: 0,
-                recoveredAfterRetry: 0,
-                lastIssue: emptyMessage,
-              }));
-              setActiveIncident(
-                createUserIncident('download', emptyMessage, {
-                  severity: 'warning',
-                })
-              );
-              encounteredEmptySource = true;
-              continue;
-            }
-
-            addLog(`Collected ${totalPhotos} photos metadata`, 'success');
-
-            addLog('Downloading user photos...', 'info');
-            const downloadPhotosResult = await window.electronAPI.downloadPhotos({
-              accountId,
-              token: token.trim() || undefined,
-            });
-
-            if (!downloadPhotosResult.success || !downloadPhotosResult.data) {
-              throw new Error(
-                downloadPhotosResult.error || 'Failed to download photos'
-              );
-            }
-
-            reportDownloadResult({
-              operation: 'User Photos Download',
-              label: 'User photos download',
-              result: downloadPhotosResult.data,
-              directoryPath: downloadPhotosResult.data.photosDirectory,
-              directoryLabel: 'User photos saved to',
-            });
-            loadPhotosForAccount(accountId);
+            addLog(
+              `Collected user photo metadata for ${totalPhotos} image(s).`,
+              'success'
+            );
             continue;
           }
 
@@ -577,45 +557,70 @@ function App() {
               );
             }
 
-            addLog('Downloading profile picture history...', 'info');
-            const downloadProfileHistoryResult =
-              await window.electronAPI.downloadProfileHistory({
+            addLog('Collecting profile picture history metadata...', 'info');
+            const collectProfileHistoryResult =
+              await window.electronAPI.collectProfileHistoryManifest({
                 accountId,
                 token: token.trim(),
               });
 
             if (
-              !downloadProfileHistoryResult.success ||
-              !downloadProfileHistoryResult.data
+              !collectProfileHistoryResult.success ||
+              !collectProfileHistoryResult.data
             ) {
               throw new Error(
-                downloadProfileHistoryResult.error ||
-                  'Failed to download profile picture history'
+                collectProfileHistoryResult.error ||
+                  'Failed to collect profile picture history metadata'
               );
             }
 
-            reportDownloadResult({
-              operation: 'Profile Picture History Download',
-              label: 'Profile picture history download',
-              result: downloadProfileHistoryResult.data,
-              directoryPath:
-                downloadProfileHistoryResult.data.profileHistoryDirectory,
-              directoryLabel: 'Profile picture history saved to',
-              manifestPath:
-                downloadProfileHistoryResult.data.profileHistoryManifestPath,
-            });
+            addLog(
+              `Collected profile picture history metadata for ${
+                collectProfileHistoryResult.data.totalPhotos || 0
+              } image(s).`,
+              'success'
+            );
           }
         }
 
-        if (
-          downloadSources.downloadUserFeed ||
-          downloadSources.downloadUserPhotos
-        ) {
-          loadPhotosForAccount(accountId);
+        const preflightResult = await window.electronAPI.buildDownloadPreflight(
+          {
+            accountId,
+            downloadSources,
+          }
+        );
+
+        if (!preflightResult.success || !preflightResult.data) {
+          throw new Error(
+            preflightResult.error || 'Failed to prepare the download summary'
+          );
         }
-        if (!encounteredEmptySource) {
-          setActiveIncident(null);
+
+        const summary = preflightResult.data;
+        setShowProgressPanel(true);
+        setActiveIncident(null);
+
+        if (summary.totalRemainingToDownload === 0) {
+          addLog(
+            'Metadata saved. Everything selected is already on disk.',
+            'success'
+          );
+          setCleanCompletionProgress(
+            'Metadata saved. No new images need downloading.'
+          );
+          return;
         }
+
+        setPendingPreflight({
+          accountId,
+          request: requestState,
+          summary,
+        });
+        setConfirmationProgress(summary);
+        addLog(
+          `Metadata saved. Review ${summary.totalRemainingToDownload} new image(s) before downloading.`,
+          'info'
+        );
       }
     } catch (error) {
       const errorMessage =
@@ -627,12 +632,14 @@ function App() {
         setProgress(prev => ({
           ...prev,
           isRunning: false,
+          phase: 'cancelled',
           currentStep: 'Cancelled',
           total: 0,
           current: 0,
           statusLevel: 'info',
           issueCount: 0,
           failedItems: 0,
+          confirmation: undefined,
           lastIssue: undefined,
         }));
         setActiveIncident(
@@ -644,27 +651,26 @@ function App() {
         setProgress(prev => ({
           ...prev,
           isRunning: false,
+          phase: 'complete',
           currentStep: EMPTY_DOWNLOAD_STEP,
           progress: 100,
           total: 0,
           current: 0,
-          statusLevel: 'warning',
+          statusLevel: 'info',
           issueCount: 0,
           failedItems: 0,
+          confirmation: undefined,
           lastIssue: classifiedError.detail,
         }));
-        setActiveIncident(
-          createUserIncident('download', errorMessage, { severity: 'warning' })
-        );
+        setActiveIncident(null);
       } else {
         addLog(`Download failed: ${errorMessage}`, 'error');
-        classifiedError.guidance.forEach(message =>
-          addLog(message, 'warning')
-        );
+        classifiedError.guidance.forEach(message => addLog(message, 'warning'));
         setShowProgressPanel(true);
         setProgress(prev => ({
           ...prev,
           isRunning: false,
+          phase: 'failed',
           currentStep: 'Failed',
           progress: 100,
           total: 0,
@@ -672,6 +678,7 @@ function App() {
           statusLevel: 'error',
           issueCount: Math.max(prev.issueCount, 1),
           failedItems: Math.max(prev.failedItems, 1),
+          confirmation: undefined,
           lastIssue: errorMessage,
         }));
         setActiveIncident(createUserIncident('download', errorMessage));
@@ -683,24 +690,188 @@ function App() {
       }
     } finally {
       setIsDownloading(false);
+    }
+  };
+
+  const handleConfirmDownload = useCallback(async () => {
+    if (!pendingPreflight || !window.electronAPI) {
+      return;
+    }
+
+    const { accountId, request, summary } = pendingPreflight;
+    const selectedSources = getSelectedDownloadSources(request.downloadSources);
+    let failedDownloads = 0;
+    let ranPhotoDownloads = false;
+
+    setPendingPreflight(null);
+    setActiveIncident(null);
+    setIsDownloading(true);
+    setShowProgressPanel(true);
+    addLog('Image download confirmed. Starting file downloads...', 'info');
+
+    try {
+      for (const source of selectedSources) {
+        const sourceSummary = summary.sourceSummaries.find(
+          item => item.source === source
+        );
+        if (!sourceSummary || sourceSummary.totalImages === 0) {
+          continue;
+        }
+
+        if (source === 'user-feed') {
+          addLog('Downloading feed photos...', 'info');
+          const downloadFeedResult =
+            await window.electronAPI.downloadFeedPhotos({
+              accountId,
+              token: request.token.trim() || undefined,
+            });
+
+          if (!downloadFeedResult.success || !downloadFeedResult.data) {
+            throw new Error(
+              downloadFeedResult.error || 'Failed to download feed photos'
+            );
+          }
+
+          ranPhotoDownloads = true;
+          failedDownloads +=
+            downloadFeedResult.data.downloadStats.failedDownloads;
+          reportDownloadResult({
+            operation: 'User Feed Download',
+            label: 'Feed download',
+            result: downloadFeedResult.data,
+            directoryPath: downloadFeedResult.data.feedPhotosDirectory,
+            directoryLabel: 'Feed photos saved to',
+          });
+          continue;
+        }
+
+        if (source === 'user-photos') {
+          addLog('Downloading user photos...', 'info');
+          const downloadPhotosResult = await window.electronAPI.downloadPhotos({
+            accountId,
+            token: request.token.trim() || undefined,
+          });
+
+          if (!downloadPhotosResult.success || !downloadPhotosResult.data) {
+            throw new Error(
+              downloadPhotosResult.error || 'Failed to download photos'
+            );
+          }
+
+          ranPhotoDownloads = true;
+          failedDownloads +=
+            downloadPhotosResult.data.downloadStats.failedDownloads;
+          reportDownloadResult({
+            operation: 'User Photos Download',
+            label: 'User photos download',
+            result: downloadPhotosResult.data,
+            directoryPath: downloadPhotosResult.data.photosDirectory,
+            directoryLabel: 'User photos saved to',
+          });
+          continue;
+        }
+
+        if (source === 'profile-history') {
+          addLog('Downloading profile picture history...', 'info');
+          const downloadProfileHistoryResult =
+            await window.electronAPI.downloadProfileHistory({
+              accountId,
+              token: request.token.trim(),
+            });
+
+          if (
+            !downloadProfileHistoryResult.success ||
+            !downloadProfileHistoryResult.data
+          ) {
+            throw new Error(
+              downloadProfileHistoryResult.error ||
+                'Failed to download profile picture history'
+            );
+          }
+
+          ranPhotoDownloads = true;
+          failedDownloads +=
+            downloadProfileHistoryResult.data.downloadStats.failedDownloads;
+          reportDownloadResult({
+            operation: 'Profile Picture History Download',
+            label: 'Profile picture history download',
+            result: downloadProfileHistoryResult.data,
+            directoryPath:
+              downloadProfileHistoryResult.data.profileHistoryDirectory,
+            directoryLabel: 'Profile picture history saved to',
+            manifestPath:
+              downloadProfileHistoryResult.data.profileHistoryManifestPath,
+          });
+        }
+      }
+
+      if (
+        request.downloadSources.downloadUserFeed ||
+        request.downloadSources.downloadUserPhotos
+      ) {
+        loadPhotosForAccount(accountId);
+      }
+
+      if (!ranPhotoDownloads) {
+        setCleanCompletionProgress(
+          'Metadata saved. No new images needed downloading.'
+        );
+      } else if (failedDownloads === 0) {
+        setActiveIncident(null);
+        setCleanCompletionProgress('Completed download');
+        addLog(
+          'Download complete. Run this again later to pick up anything new from Rec Room.',
+          'success'
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Download failed';
+      addLog(`Download failed: ${errorMessage}`, 'error');
       setProgress(prev => ({
         ...prev,
         isRunning: false,
-        currentStep:
-          prev.currentStep === 'Cancelled'
-            ? 'Cancelled'
-            : prev.currentStep === 'Failed'
-              ? 'Failed'
-              : prev.currentStep === EMPTY_DOWNLOAD_STEP
-                ? EMPTY_DOWNLOAD_STEP
-              : 'Complete',
-        progress:
-          prev.currentStep === 'Cancelled' ? prev.progress : 100,
+        phase: 'failed',
+        currentStep: 'Failed',
+        progress: 100,
         total: 0,
         current: 0,
+        statusLevel: 'error',
+        issueCount: Math.max(prev.issueCount, 1),
+        failedItems: Math.max(prev.failedItems, 1),
+        confirmation: undefined,
+        lastIssue: errorMessage,
       }));
+      setActiveIncident(createUserIncident('download', errorMessage));
+      addResult(
+        'Download',
+        toOperationErrorData(errorMessage, 'download'),
+        'error'
+      );
+    } finally {
+      setIsDownloading(false);
     }
-  };
+  }, [
+    addLog,
+    addResult,
+    loadPhotosForAccount,
+    pendingPreflight,
+    reportDownloadResult,
+    setCleanCompletionProgress,
+  ]);
+
+  const handleSkipDownload = useCallback(() => {
+    if (!pendingPreflight) {
+      return;
+    }
+
+    addLog('Metadata saved. Image download skipped.', 'info');
+    setPendingPreflight(null);
+    setActiveIncident(null);
+    setCleanCompletionProgress(
+      'Metadata saved. Image download was skipped for now.'
+    );
+  }, [addLog, pendingPreflight, setCleanCompletionProgress]);
 
   const handleRetryDownload = useCallback(async () => {
     if (!retryRequest || isDownloading) {
@@ -747,6 +918,7 @@ function App() {
           setProgress(prev => ({
             ...prev,
             isRunning: false,
+            phase: 'cancelled',
             currentStep: 'Cancelled',
             progress: 0,
             total: 0,
@@ -798,25 +970,25 @@ function App() {
     <FavoritesProvider>
       <div className="min-h-screen bg-background">
         {/* Custom Title Bar */}
-          <CustomTitleBar
-            onDownloadClick={() => setDownloadPanelOpen(true)}
-            onStatsClick={() => setStatsDialogOpen(true)}
-            settings={settings}
-            onUpdateSettings={updateSettings}
-            logs={logs}
-            results={results}
-            onClearLogs={clearLogs}
-            currentAccountId={currentAccountId}
-            debugMenuOpen={debugMenuOpen}
-            onDebugMenuOpenChange={setDebugMenuOpen}
-            resultsScrollRequestId={resultsScrollRequestId}
-            onRetryDownload={handleRetryDownload}
-            canRetryDownload={canRetryDownload}
-            isRetryingDownload={isDownloading}
-            onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
-            onOpenOutputFolder={handleOpenPathInExplorer}
-            outputRoot={settings.outputRoot}
-          />
+        <CustomTitleBar
+          onDownloadClick={() => setDownloadPanelOpen(true)}
+          onStatsClick={() => setStatsDialogOpen(true)}
+          settings={settings}
+          onUpdateSettings={updateSettings}
+          logs={logs}
+          results={results}
+          onClearLogs={clearLogs}
+          currentAccountId={currentAccountId}
+          debugMenuOpen={debugMenuOpen}
+          onDebugMenuOpenChange={setDebugMenuOpen}
+          resultsScrollRequestId={resultsScrollRequestId}
+          onRetryDownload={handleRetryDownload}
+          canRetryDownload={canRetryDownload}
+          isRetryingDownload={isDownloading}
+          onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+          onOpenOutputFolder={handleOpenPathInExplorer}
+          outputRoot={settings.outputRoot}
+        />
 
         <div className="container mx-auto px-4 py-4 max-w-7xl h-screen flex flex-col overflow-hidden pt-14">
           <ErrorRecoveryBanner
@@ -840,7 +1012,8 @@ function App() {
               onDownload={handleDownload}
               onDraftChange={handleDownloadDraftChange}
               onCancel={handleCancelDownload}
-              isDownloading={isDownloading}
+              isDownloading={isDownloading || !!pendingPreflight}
+              showCancel={isDownloading}
               settings={settings}
             />
           </ErrorBoundary>
@@ -863,6 +1036,8 @@ function App() {
                 onClose={() => setShowProgressPanel(false)}
                 onOpenOperationResults={openOperationResults}
                 onOpenDownloadPanel={() => setDownloadPanelOpen(true)}
+                onConfirmDownload={handleConfirmDownload}
+                onSkipDownload={handleSkipDownload}
                 onRetryDownload={handleRetryDownload}
                 canRetryDownload={canRetryDownload}
                 isRetrying={isDownloading}

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -65,6 +65,7 @@ interface DownloadPanelProps {
   onDraftChange?: (draft: DownloadDraft) => void;
   onCancel?: () => void;
   isDownloading?: boolean;
+  showCancel?: boolean;
   settings: RecNetSettings;
 }
 
@@ -78,6 +79,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   onDraftChange,
   onCancel,
   isDownloading = false,
+  showCancel = false,
   settings,
 }) => {
   const electronAPI = (window as unknown as { electronAPI?: any }).electronAPI;
@@ -795,7 +797,7 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
               <Download className="mr-2 h-4 w-4" />
               Download
             </Button>
-            {isDownloading && onCancel && (
+            {showCancel && onCancel && (
               <Button
                 onClick={onCancel}
                 variant="destructive"

--- a/src/renderer/components/ProgressDisplay.tsx
+++ b/src/renderer/components/ProgressDisplay.tsx
@@ -14,6 +14,7 @@ import {
   X,
   AlertTriangle,
   AlertCircle,
+  Download,
 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 
@@ -22,9 +23,32 @@ interface ProgressDisplayProps {
   onClose?: () => void;
   onOpenOperationResults?: () => void;
   onOpenDownloadPanel?: () => void;
+  onConfirmDownload?: () => void | Promise<void>;
+  onSkipDownload?: () => void;
   onRetryDownload?: () => void | Promise<void>;
   canRetryDownload?: boolean;
   isRetrying?: boolean;
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatImageCount(value: number): string {
+  return `${formatCount(value)} new image${value === 1 ? '' : 's'}`;
+}
+
+function getDownloadPhaseLabel(source?: ProgressType['currentSource']): string {
+  switch (source) {
+    case 'user-feed':
+      return 'Feed';
+    case 'user-photos':
+      return 'User';
+    case 'profile-history':
+      return 'Profile History';
+    default:
+      return 'Image';
+  }
 }
 
 export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
@@ -32,6 +56,8 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
   onClose,
   onOpenOperationResults,
   onOpenDownloadPanel,
+  onConfirmDownload,
+  onSkipDownload,
   onRetryDownload,
   canRetryDownload = false,
   isRetrying = false,
@@ -40,25 +66,26 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
     Math.max(Math.round(progress.progress ?? 0), 0),
     100
   );
-  const hasTotals = progress.total > 0;
-  const isComplete = !progress.isRunning && percent >= 100;
+  const isConfirming = progress.phase === 'confirm' && !!progress.confirmation;
+  const hasTotals = progress.total > 0 && !isConfirming;
   const isCancelled =
-    !progress.isRunning && progress.currentStep === 'Cancelled';
-  const hasIssues = progress.issueCount > 0;
-  const hasFailures =
+    progress.phase === 'cancelled' ||
+    (!progress.isRunning && progress.currentStep === 'Cancelled');
+  const isComplete = progress.phase === 'complete' && !progress.isRunning;
+  const hasOutstandingFailures =
     !isCancelled &&
-    (progress.failedItems > 0 || progress.statusLevel === 'error');
-  const isRetryableCompletion =
-    !progress.isRunning &&
-    progress.currentStep === 'Complete' &&
-    progress.failedItems > 0;
-  const showErrorTone = hasFailures && !isRetryableCompletion;
-  const showWarningTone = hasIssues || isRetryableCompletion;
+    (progress.phase === 'failed' ||
+      progress.failedItems > 0 ||
+      progress.statusLevel === 'error');
+  const hasActiveWarnings =
+    progress.isRunning && !hasOutstandingFailures && progress.issueCount > 0;
+  const showErrorTone = hasOutstandingFailures;
+  const showWarningTone = hasActiveWarnings;
   const [indeterminateValue, setIndeterminateValue] = useState(15);
   const directionRef = useRef<1 | -1>(1);
 
   useEffect(() => {
-    if (!progress.isRunning || hasTotals) {
+    if (!progress.isRunning || hasTotals || isConfirming) {
       setIndeterminateValue(15);
       directionRef.current = 1;
       return;
@@ -83,7 +110,7 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
     }, 120);
 
     return () => clearInterval(interval);
-  }, [progress.isRunning, hasTotals]);
+  }, [progress.isRunning, hasTotals, isConfirming]);
 
   const isIdle =
     !progress.isRunning &&
@@ -113,16 +140,65 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
       : progress.isRunning
         ? 'text-primary'
         : 'text-muted-foreground';
-  const canOpenIssueDetails =
-    (showErrorTone || isRetryableCompletion) && !!onOpenOperationResults;
-  const issueMessage = isRetryableCompletion
-    ? 'The download finished, but some images were missed. Retry the download now to grab any missed images.'
-    : progress.lastIssue ||
-      'Some files are retrying. The download is still moving, but it is not clean.';
 
   if (isIdle) {
     return null;
   }
+
+  const confirmation = progress.confirmation;
+  const issueMessage =
+    progress.lastIssue ||
+    'The app hit a problem and is retrying or waiting for attention.';
+  const completionFollowUpMessage =
+    'Want to verify the download or grab any new photos later? Just run the download again and the app will only download new content.';
+  const downloadPhaseMessage =
+    progress.phase === 'download'
+      ? `Downloading ${getDownloadPhaseLabel(progress.currentSource)} Images...`
+      : undefined;
+  const activityMessage = isConfirming
+    ? undefined
+    : progress.phase === 'download'
+      ? undefined
+    : isComplete && !showErrorTone && !isCancelled
+      ? completionFollowUpMessage
+      : progress.recentActivity;
+  const canOpenIssueDetails =
+    (showErrorTone || showWarningTone) && !!onOpenOperationResults;
+  const totalPrivateImagesToDownload =
+    confirmation?.sourceSummaries.reduce(
+      (sum, source) => sum + (source.privateImagesToDownload ?? 0),
+      0
+    ) ?? 0;
+  const description = isCancelled
+    ? 'You cancelled this run. You can start a new download anytime.'
+    : isComplete && !showErrorTone
+      ? ''
+    : isConfirming
+      ? ''
+      : downloadPhaseMessage
+        ? downloadPhaseMessage
+      : progress.currentStep || (isComplete ? 'Complete' : 'Ready');
+  const titleText =
+    isComplete && !showErrorTone && !isCancelled
+      ? 'Download Completed'
+      : 'Download Progress';
+  const statusText = isCancelled
+    ? 'Cancelled'
+    : isConfirming
+      ? 'Ready to download'
+      : progress.isRunning
+        ? showErrorTone
+          ? 'Issues detected'
+          : showWarningTone
+            ? 'Retrying'
+            : progress.phase === 'metadata'
+              ? 'Collecting metadata'
+              : 'Downloading'
+        : showErrorTone
+          ? 'Complete with failures'
+          : isComplete
+            ? 'Complete'
+            : 'Idle';
 
   return (
     <Card className={cardToneClass}>
@@ -135,16 +211,14 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
               <AlertCircle className="h-5 w-5 text-red-500" />
             ) : showWarningTone ? (
               <AlertTriangle className="h-5 w-5 text-yellow-500" />
+            ) : isConfirming ? (
+              <Download className="h-5 w-5 text-primary" />
             ) : progress.isRunning ? (
               <Loader2 className="h-5 w-5 animate-spin" />
-            ) : null}
-            {isComplete &&
-              !progress.isRunning &&
-              !showWarningTone &&
-              !isCancelled && (
-                <CheckCircle2 className="h-5 w-5 text-green-500" />
-              )}
-            Download Progress
+            ) : (
+              <CheckCircle2 className="h-5 w-5 text-green-500" />
+            )}
+            {titleText}
           </span>
           {onClose && (
             <Button
@@ -157,16 +231,10 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
             </Button>
           )}
         </CardTitle>
-        <CardDescription>
-          {isCancelled
-            ? 'You cancelled this run. You can start a new download anytime.'
-            : isRetryableCompletion
-              ? 'Download complete. Retry the same download to grab any missed images.'
-            : progress.currentStep || (isComplete ? 'Complete' : 'Ready')}
-        </CardDescription>
+        {description ? <CardDescription>{description}</CardDescription> : null}
       </CardHeader>
-      <CardContent className="space-y-4">
-        {showWarningTone && !isCancelled && (
+      <CardContent className="max-h-[calc(100vh-8rem)] space-y-4 overflow-y-auto px-6 pb-6 pt-0">
+        {(showErrorTone || showWarningTone) && !isCancelled && (
           <div
             className={
               showErrorTone
@@ -180,16 +248,6 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
             onClick={canOpenIssueDetails ? onOpenOperationResults : undefined}
             role={canOpenIssueDetails ? 'button' : undefined}
             tabIndex={canOpenIssueDetails ? 0 : undefined}
-            onKeyDown={
-              canOpenIssueDetails
-                ? event => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault();
-                      onOpenOperationResults?.();
-                    }
-                  }
-                : undefined
-            }
           >
             <div className="flex items-start gap-3">
               {showErrorTone ? (
@@ -208,9 +266,7 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
                   >
                     {showErrorTone
                       ? 'Download issues need attention'
-                      : isRetryableCompletion
-                        ? 'Download completed with missed images'
-                        : 'Download issues detected'}
+                      : 'Download issues detected'}
                   </p>
                   <p
                     className={
@@ -221,17 +277,6 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
                   >
                     {issueMessage}
                   </p>
-                  {canOpenIssueDetails && (
-                    <p
-                      className={
-                        showErrorTone
-                          ? 'pt-1 text-xs font-medium text-red-700 underline underline-offset-2 dark:text-red-300'
-                          : 'pt-1 text-xs font-medium text-yellow-800 underline underline-offset-2 dark:text-yellow-200'
-                      }
-                    >
-                      Click this area to jump to Operation Results.
-                    </p>
-                  )}
                 </div>
 
                 <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
@@ -251,7 +296,9 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
 
                 {(onOpenOperationResults ||
                   onOpenDownloadPanel ||
-                  (onRetryDownload && canRetryDownload)) && (
+                  (onRetryDownload &&
+                    canRetryDownload &&
+                    !progress.isRunning)) && (
                   <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:flex-wrap">
                     {onOpenOperationResults && (
                       <Button
@@ -302,28 +349,39 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
           </div>
         )}
 
-        <div className="flex justify-between text-sm">
-          <span className="text-muted-foreground">Status</span>
-          <span className={statusToneClass}>
-            {isCancelled
-              ? 'Cancelled'
-              : progress.isRunning
-                ? showErrorTone
-                  ? 'Issues detected'
-                  : showWarningTone
-                    ? 'Retrying with warnings'
-                    : 'In progress'
-                : isComplete
-                  ? isRetryableCompletion
-                    ? 'Complete with missed images'
-                    : showErrorTone
-                      ? 'Complete with failures'
-                      : showWarningTone
-                      ? 'Complete with warnings'
-                      : 'Complete'
-                  : 'Idle'}
-          </span>
-        </div>
+        {!isConfirming && (
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Status</span>
+            <span className={statusToneClass}>{statusText}</span>
+          </div>
+        )}
+
+        {progress.phase === 'metadata' &&
+          (progress.pageLabel || progress.currentSource) && (
+            <div className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-3">
+              {progress.currentSource && (
+                <div className="rounded border border-border/70 px-2 py-1">
+                  Source: {progress.currentSource}
+                </div>
+              )}
+              {progress.pageLabel && (
+                <div className="rounded border border-border/70 px-2 py-1">
+                  Step: {progress.pageLabel}
+                </div>
+              )}
+              {progress.activeItemLabel && (
+                <div className="rounded border border-border/70 px-2 py-1">
+                  Item: {progress.activeItemLabel}
+                </div>
+              )}
+            </div>
+          )}
+
+        {activityMessage && (
+          <div className="rounded border border-border/70 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+            {activityMessage}
+          </div>
+        )}
 
         {hasTotals && (
           <>
@@ -337,13 +395,101 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
           </>
         )}
 
-        {!hasTotals && (
-          <>
-            <Progress value={barValue} className={`h-2 ${progressToneClass}`} />
-            <div className="text-sm text-muted-foreground">
-              {progress.currentStep || 'Waiting to start'}
+        {!hasTotals && progress.isRunning && !isConfirming && (
+          <Progress value={barValue} className={`h-2 ${progressToneClass}`} />
+        )}
+
+        {isConfirming && confirmation && (
+          <div className="space-y-4 rounded-2xl bg-muted/20 p-4">
+            {totalPrivateImagesToDownload === 0 && (
+              <div className="rounded-2xl bg-yellow-50/40 px-4 py-3 text-sm text-yellow-800/80 ring-1 ring-yellow-200/60 dark:bg-yellow-950/20 dark:text-yellow-300/75 dark:ring-yellow-900/50">
+                No private photos are included in this download.
+              </div>
+            )}
+
+            <div className="space-y-3 rounded-2xl bg-background/80 px-5 py-5 shadow-sm ring-1 ring-border/50">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                Download Summary
+              </p>
+              <div className="space-y-1">
+                <h3 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+                  {formatImageCount(confirmation.totalRemainingToDownload)}
+                </h3>
+              </div>
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <p>
+                  {formatCount(confirmation.totalImages)} total images found
+                </p>
+                <p>
+                  {formatCount(confirmation.totalAlreadyOnDisk)} are already on
+                  disk and will be skipped automatically
+                </p>
+              </div>
             </div>
-          </>
+
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {confirmation.sourceSummaries.map(source => (
+                <div
+                  key={source.source}
+                  className="space-y-3 rounded-2xl bg-background/80 px-4 py-4 shadow-sm ring-1 ring-border/50"
+                >
+                  <div className="space-y-1">
+                    <h4 className="text-base font-semibold">{source.label}</h4>
+                    <p className="text-2xl font-semibold tracking-tight">
+                      {formatImageCount(source.remainingToDownload)}
+                    </p>
+                  </div>
+                  <div className="space-y-1 text-sm text-muted-foreground">
+                    <p>Total found: {formatCount(source.totalImages)}</p>
+                    <p>
+                      {formatCount(source.alreadyOnDisk)} already on disk and
+                      will be skipped
+                    </p>
+                  </div>
+                  {(source.source === 'user-feed' ||
+                    source.source === 'user-photos') &&
+                    (source.privateImagesToDownload ?? 0) > 0 && (
+                      <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                        Includes{' '}
+                        {formatCount(source.privateImagesToDownload ?? 0)}{' '}
+                        private image
+                        {(source.privateImagesToDownload ?? 0) === 1 ? '' : 's'}
+                        .
+                      </p>
+                    )}
+                </div>
+              ))}
+            </div>
+
+            {(onConfirmDownload || onSkipDownload) && (
+              <div className="space-y-3 pt-1">
+                <p className="text-sm text-muted-foreground">
+                  Files already on disk will be skipped automatically.
+                </p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  {onConfirmDownload && (
+                    <Button
+                      onClick={() => void onConfirmDownload()}
+                      className="sm:flex-1"
+                    >
+                      Download{' '}
+                      {formatCount(confirmation.totalRemainingToDownload)} image
+                      {confirmation.totalRemainingToDownload === 1 ? '' : 's'}
+                    </Button>
+                  )}
+                  {onSkipDownload && (
+                    <Button
+                      variant="outline"
+                      onClick={onSkipDownload}
+                      className="sm:flex-1"
+                    >
+                      Cancel Download
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
         )}
 
         {isCancelled && !progress.isRunning && (
@@ -359,7 +505,7 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
                 disabled={isRetrying}
                 onClick={() => void onRetryDownload()}
               >
-                {isRetrying ? 'Starting…' : 'Run download again'}
+                {isRetrying ? 'Starting...' : 'Run download again'}
               </Button>
             )}
           </div>

--- a/src/renderer/components/ProgressDisplay.tsx
+++ b/src/renderer/components/ProgressDisplay.tsx
@@ -23,6 +23,7 @@ interface ProgressDisplayProps {
   onClose?: () => void;
   onOpenOperationResults?: () => void;
   onOpenDownloadPanel?: () => void;
+  onCancelDownload?: () => void | Promise<void>;
   onConfirmDownload?: () => void | Promise<void>;
   onSkipDownload?: () => void;
   onRetryDownload?: () => void | Promise<void>;
@@ -56,6 +57,7 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
   onClose,
   onOpenOperationResults,
   onOpenDownloadPanel,
+  onCancelDownload,
   onConfirmDownload,
   onSkipDownload,
   onRetryDownload,
@@ -397,6 +399,14 @@ export const ProgressDisplay: React.FC<ProgressDisplayProps> = ({
 
         {!hasTotals && progress.isRunning && !isConfirming && (
           <Progress value={barValue} className={`h-2 ${progressToneClass}`} />
+        )}
+
+        {progress.isRunning && !isConfirming && onCancelDownload && (
+          <div className="flex justify-end border-t border-border/60 pt-3">
+            <Button variant="destructive" size="sm" onClick={() => void onCancelDownload()}>
+              Cancel Download
+            </Button>
+          </div>
         )}
 
         {isConfirming && confirmation && (

--- a/src/renderer/utils/__tests__/downloadProgressFeedback.test.ts
+++ b/src/renderer/utils/__tests__/downloadProgressFeedback.test.ts
@@ -7,6 +7,7 @@ import {
 function createProgress(overrides: Partial<Progress> = {}): Progress {
   return {
     isRunning: false,
+    phase: 'complete',
     currentStep: 'Ready',
     progress: 0,
     total: 0,
@@ -26,6 +27,7 @@ describe('downloadProgressFeedback', () => {
     const incident = buildDownloadProgressIncident(
       createProgress({
         isRunning: true,
+        phase: 'download',
         currentStep: 'Downloading user photos...',
         issueCount: 1,
         retryAttempts: 1,
@@ -44,6 +46,7 @@ describe('downloadProgressFeedback', () => {
     const incident = buildDownloadProgressIncident(
       createProgress({
         isRunning: true,
+        phase: 'download',
         currentStep: 'Downloading user photos...',
         issueCount: 1,
         retryAttempts: 1,
@@ -61,6 +64,7 @@ describe('downloadProgressFeedback', () => {
     const incident = buildDownloadProgressIncident(
       createProgress({
         isRunning: false,
+        phase: 'complete',
         currentStep: 'Complete',
         issueCount: 4,
         retryAttempts: 3,
@@ -82,6 +86,7 @@ describe('downloadProgressFeedback', () => {
     const incident = buildDownloadProgressIncident(
       createProgress({
         isRunning: false,
+        phase: 'cancelled',
         currentStep: 'Cancelled',
       })
     );
@@ -94,10 +99,12 @@ describe('downloadProgressFeedback', () => {
   it('emits log entries for issue and recovery transitions', () => {
     const previous = createProgress({
       isRunning: true,
+      phase: 'download',
       currentStep: 'Downloading user photos...',
     });
     const warningProgress = createProgress({
       isRunning: true,
+      phase: 'download',
       currentStep: 'Downloading user photos...',
       issueCount: 1,
       retryAttempts: 1,
@@ -105,6 +112,7 @@ describe('downloadProgressFeedback', () => {
     });
     const recoveredProgress = createProgress({
       isRunning: true,
+      phase: 'download',
       currentStep: 'Downloading user photos...',
       issueCount: 1,
       retryAttempts: 1,
@@ -127,5 +135,34 @@ describe('downloadProgressFeedback', () => {
         type: 'success',
       },
     ]);
+  });
+
+  it('does not create a lingering incident after a clean recovered completion', () => {
+    const incident = buildDownloadProgressIncident(
+      createProgress({
+        isRunning: false,
+        phase: 'complete',
+        currentStep: 'Complete',
+        issueCount: 1,
+        retryAttempts: 1,
+        recoveredAfterRetry: 1,
+        failedItems: 0,
+        lastIssue: 'Recovered image1.jpg after 1 retry. Download is continuing.',
+      })
+    );
+
+    expect(incident).toBeNull();
+  });
+
+  it('does not create an incident while waiting on confirmation', () => {
+    const incident = buildDownloadProgressIncident(
+      createProgress({
+        isRunning: false,
+        phase: 'confirm',
+        currentStep: 'Metadata is ready.',
+      })
+    );
+
+    expect(incident).toBeNull();
   });
 });

--- a/src/renderer/utils/downloadProgressFeedback.ts
+++ b/src/renderer/utils/downloadProgressFeedback.ts
@@ -35,6 +35,10 @@ export function buildDownloadProgressIncident(
 ): UserFacingIncident | null {
   const detail = trimMessage(progress.lastIssue);
 
+  if (progress.phase === 'confirm') {
+    return null;
+  }
+
   if (progress.currentStep === 'Cancelled') {
     return createIncident(
       'Download cancelled',
@@ -46,11 +50,7 @@ export function buildDownloadProgressIncident(
     );
   }
 
-  if (
-    progress.issueCount === 0 &&
-    progress.recoveredAfterRetry === 0 &&
-    progress.failedItems === 0
-  ) {
+  if (progress.issueCount === 0 && progress.failedItems === 0) {
     return null;
   }
 
@@ -65,6 +65,10 @@ export function buildDownloadProgressIncident(
       ],
       { severity: 'error' }
     );
+  }
+
+  if (!progress.isRunning && progress.failedItems === 0) {
+    return null;
   }
 
   if (detail.toLowerCase().startsWith('recovered ')) {
@@ -93,17 +97,6 @@ export function buildDownloadProgressIncident(
         'The app is retrying the affected file now.',
         'The download is still running and you can cancel it if needed.',
         'If retries run out, run the same download again; existing files will be skipped.',
-      ]
-    );
-  }
-
-  if (!progress.isRunning && progress.issueCount > 0) {
-    return createIncident(
-      'Download finished after retrying',
-      detail || 'The app hit issues during the download but recovered.',
-      [
-        'The app recovered from the issue and completed the run.',
-        'Anything already saved on disk stays in place.',
       ]
     );
   }

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -7,15 +7,18 @@ import type {
   ApiResponse,
   AvailableAccount,
   CollectionResult,
+  DownloadPreflightSummary,
   DownloadResult,
   EventDto,
   Photo,
   ProfileHistoryAccessResult,
+  ProfileHistoryCollectionResult,
   PlayerResult,
   Progress,
   RecNetSettings,
   RoomDto,
 } from './types';
+import type { DownloadSourceSelection } from './download-sources';
 
 export interface ElectronAPI {
   collectPhotos: (params: {
@@ -34,6 +37,14 @@ export interface ElectronAPI {
     forceRoomsRefresh?: boolean;
     forceEventsRefresh?: boolean;
   }) => Promise<ApiResponse<CollectionResult>>;
+  collectProfileHistoryManifest: (params: {
+    accountId: string;
+    token: string;
+  }) => Promise<ApiResponse<ProfileHistoryCollectionResult>>;
+  buildDownloadPreflight: (params: {
+    accountId: string;
+    downloadSources: DownloadSourceSelection;
+  }) => Promise<ApiResponse<DownloadPreflightSummary>>;
 
   downloadPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;
   downloadFeedPhotos: (params: { accountId: string; token?: string }) => Promise<ApiResponse<DownloadResult>>;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,6 +2,7 @@ import { EventDto } from '../../main/models/EventDto';
 import { ImageDto } from '../../main/models/ImageDto';
 import { PlayerResult } from '../../main/models/PlayerDto';
 import { RoomDto } from '../../main/models/RoomDto';
+import type { DownloadSource } from '../download-sources';
 
 export type { EventDto, ImageDto, PlayerResult, RoomDto };
 
@@ -22,6 +23,13 @@ export interface BulkDataRefreshOptions {
 
 export interface Progress {
   isRunning: boolean;
+  phase:
+    | 'metadata'
+    | 'confirm'
+    | 'download'
+    | 'complete'
+    | 'cancelled'
+    | 'failed';
   currentStep: string;
   progress: number;
   total: number;
@@ -31,7 +39,12 @@ export interface Progress {
   retryAttempts: number;
   failedItems: number;
   recoveredAfterRetry: number;
+  currentSource?: DownloadSource;
+  pageLabel?: string;
+  activeItemLabel?: string;
+  recentActivity?: string;
   lastIssue?: string;
+  confirmation?: DownloadPreflightSummary;
 }
 
 export type Photo = Omit<ImageDto, 'PlayerEventId'> & {
@@ -81,6 +94,33 @@ export interface CollectionResult {
   iterationDetails: IterationDetail[];
   sinceTime?: string;
   incremental?: boolean;
+}
+
+export interface ProfileHistoryCollectionResult {
+  accountId: string;
+  saved: string;
+  existingPhotos: number;
+  totalNewPhotosAdded: number;
+  totalPhotos: number;
+}
+
+export interface DownloadPreflightSourceSummary {
+  source: DownloadSource;
+  label: string;
+  totalImages: number;
+  alreadyOnDisk: number;
+  remainingToDownload: number;
+  privateImagesToDownload?: number;
+  metadataPath?: string;
+  downloadDirectory?: string;
+}
+
+export interface DownloadPreflightSummary {
+  accountId: string;
+  sourceSummaries: DownloadPreflightSourceSummary[];
+  totalImages: number;
+  totalAlreadyOnDisk: number;
+  totalRemainingToDownload: number;
 }
 
 export interface DownloadStats {


### PR DESCRIPTION
When downloading image it will now follow this flow:
- User triggers download
- App collects metadata and shows total image counts to the user
- User has to select to download or cancel the download

Why the change?
It gives the user better insight into what is happening. If they already have images it will tell them how many images it found already saved and how many need to be downloaded.  It will also let them know if private images are being downloaded.  

Plus it just lets the user know that they are about to download X amount of images. So they can decide if they want to proceed or not with that download. If they don't proceed the metadata will still be saved.