### PR TITLE
Forced Gentle Settings

### DIFF
--- a/src/main/services/__tests__/recnet-service.save.test.ts
+++ b/src/main/services/__tests__/recnet-service.save.test.ts
@@ -81,6 +81,59 @@ describe('RecNetService - File Saving Functionality', () => {
     }
   });
 
+  describe('Settings persistence', () => {
+    it('does not persist runtime-only throttling settings to disk', async () => {
+      jest.clearAllMocks();
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+
+      const localService = new RecNetService();
+      await localService.updateSettings({
+        outputRoot: testOutputDir,
+        interPageDelayMs: 250,
+        maxConcurrentDownloads: 9,
+        maxPhotosToDownload: 4,
+      });
+
+      const savedSettings = mockedFs.writeJson.mock.calls.at(-1)?.[1] as Record<
+        string,
+        unknown
+      >;
+
+      expect(savedSettings).toMatchObject({
+        outputRoot: testOutputDir,
+        maxPhotosToDownload: 4,
+      });
+      expect(savedSettings).not.toHaveProperty('interPageDelayMs');
+      expect(savedSettings).not.toHaveProperty('maxConcurrentDownloads');
+    });
+
+    it('ignores legacy runtime-only throttling settings from disk', async () => {
+      jest.clearAllMocks();
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(true);
+      (mockedFs.readJson as jest.Mock).mockResolvedValue({
+        outputRoot: testOutputDir,
+        maxPhotosToDownload: 7,
+        interPageDelayMs: 999,
+        maxConcurrentDownloads: 25,
+      });
+
+      const localService = new RecNetService();
+      const settings = await localService.getSettings();
+
+      expect(settings.outputRoot).toBe(testOutputDir);
+      expect(settings.maxPhotosToDownload).toBe(7);
+      expect(settings.interPageDelayMs).toBe(100);
+      expect(settings.maxConcurrentDownloads).toBe(3);
+
+      const rewrittenSettings = mockedFs.writeJson.mock.calls.at(-1)?.[1] as Record<
+        string,
+        unknown
+      >;
+      expect(rewrittenSettings).not.toHaveProperty('interPageDelayMs');
+      expect(rewrittenSettings).not.toHaveProperty('maxConcurrentDownloads');
+    });
+  });
+
   /**
    * Tests for saving photo files to disk
    *

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -90,8 +90,8 @@ type DownloadBatchTrace = {
 const DEFAULT_SETTINGS: RecNetSettings = {
   outputRoot: 'output',
   cdnBase: DEFAULT_CDN_BASE,
-  interPageDelayMs: 0,
-  maxConcurrentDownloads: 30
+  interPageDelayMs: 100,
+  maxConcurrentDownloads: 3
 };
 
 const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
@@ -99,6 +99,12 @@ const PHOTO_DOWNLOAD_MAX_ATTEMPTS = PHOTO_DOWNLOAD_RETRY_COUNT + 1;
 const PHOTO_DOWNLOAD_RETRY_DELAY_MS = 750;
 const PHOTO_DOWNLOAD_TIMEOUT_MS = 15_000;
 const PHOTO_MAX_PAGE_SIZE = 1_000;
+
+type PersistedRecNetSettings = Omit<
+  RecNetSettings,
+  'interPageDelayMs' | 'maxConcurrentDownloads'
+>;
+
 function normalizeRecNetSettings(input: unknown): RecNetSettings {
   const raw =
     input && typeof input === 'object'
@@ -135,6 +141,44 @@ function normalizeRecNetSettings(input: unknown): RecNetSettings {
   };
 }
 
+function extractPersistedRecNetSettings(
+  input: unknown
+): Partial<PersistedRecNetSettings> {
+  const raw =
+    input && typeof input === 'object'
+      ? (input as Record<string, unknown>)
+      : {};
+
+  return {
+    outputRoot:
+      typeof raw.outputRoot === 'string' && raw.outputRoot.length > 0
+        ? raw.outputRoot
+        : undefined,
+    cdnBase:
+      typeof raw.cdnBase === 'string' && raw.cdnBase.length > 0
+        ? raw.cdnBase
+        : undefined,
+    maxPhotosToDownload:
+      typeof raw.maxPhotosToDownload === 'number' &&
+      Number.isFinite(raw.maxPhotosToDownload) &&
+      raw.maxPhotosToDownload > 0
+        ? Math.floor(raw.maxPhotosToDownload)
+        : undefined,
+  };
+}
+
+function hasLegacyRuntimeOnlySettings(input: unknown): boolean {
+  if (!input || typeof input !== 'object') {
+    return false;
+  }
+
+  const raw = input as Record<string, unknown>;
+  return (
+    Object.prototype.hasOwnProperty.call(raw, 'interPageDelayMs') ||
+    Object.prototype.hasOwnProperty.call(raw, 'maxConcurrentDownloads')
+  );
+}
+
 export class RecNetService extends EventEmitter {
   private settingsPath: string;
   private settings: RecNetSettings;
@@ -165,6 +209,7 @@ export class RecNetService extends EventEmitter {
     });
 
     this.httpClient = new RecNetHttpClient();
+    this.syncHttpClientSettings();
     this.photosController = new PhotosController(this.httpClient);
     this.accountsController = new AccountsController(this.httpClient);
     this.roomsController = new RoomsController(this.httpClient);
@@ -184,13 +229,18 @@ export class RecNetService extends EventEmitter {
         const savedSettings = await fs.readJson(this.settingsPath);
         this.settings = normalizeRecNetSettings({
           ...DEFAULT_SETTINGS,
-          ...savedSettings,
+          ...extractPersistedRecNetSettings(savedSettings),
         });
-        console.log('Settings loaded from disk:', this.settings);
+
+        if (hasLegacyRuntimeOnlySettings(savedSettings)) {
+          await this.saveSettings();
+        }
       }
     } catch (error) {
       console.log('Failed to load settings:', (error as Error).message);
     }
+    this.syncHttpClientSettings();
+    console.log('Settings loaded from disk:', this.settings);
     // Ensure output directory exists
     this.ensureOutputDirectory();
   }
@@ -198,8 +248,9 @@ export class RecNetService extends EventEmitter {
   async saveSettings(): Promise<void> {
     try {
       await fs.ensureDir(path.dirname(this.settingsPath));
-      await fs.writeJson(this.settingsPath, this.settings, { spaces: 2 });
-      console.log('Settings saved to disk:', this.settings);
+      const persistedSettings = this.getPersistedSettingsForDisk();
+      await fs.writeJson(this.settingsPath, persistedSettings, { spaces: 2 });
+      console.log('Settings saved to disk:', persistedSettings);
     } catch (error) {
       console.log('Failed to save settings:', (error as Error).message);
     }
@@ -207,6 +258,18 @@ export class RecNetService extends EventEmitter {
 
   private ensureOutputDirectory(): void {
     fs.ensureDirSync(this.settings.outputRoot);
+  }
+
+  private syncHttpClientSettings(): void {
+    this.httpClient.setRequestDelayMs(this.settings.interPageDelayMs || 0);
+  }
+
+  private getPersistedSettingsForDisk(): PersistedRecNetSettings {
+    return {
+      outputRoot: this.settings.outputRoot,
+      cdnBase: this.settings.cdnBase,
+      maxPhotosToDownload: this.settings.maxPhotosToDownload,
+    };
   }
 
   async getSettings(): Promise<RecNetSettings> {
@@ -222,6 +285,7 @@ export class RecNetService extends EventEmitter {
       ...this.settings,
       ...newSettings,
     });
+    this.syncHttpClientSettings();
     this.ensureOutputDirectory();
     await this.saveSettings();
     return this.settings;
@@ -621,10 +685,6 @@ export class RecNetService extends EventEmitter {
         if (hasMorePhotos) {
           skip += PHOTO_MAX_PAGE_SIZE;
           iteration++;
-
-          if (this.settings.interPageDelayMs) {
-            await this.delay(this.settings.interPageDelayMs, operation);
-          }
         }
       }
 
@@ -937,10 +997,6 @@ export class RecNetService extends EventEmitter {
         if (hasMoreFeedPhotos) {
           skip += PHOTO_MAX_PAGE_SIZE;
           iteration++;
-
-          if (this.settings.interPageDelayMs) {
-            await this.delay(this.settings.interPageDelayMs, operation);
-          }
         }
       }
 
@@ -1147,7 +1203,6 @@ export class RecNetService extends EventEmitter {
         0
       );
 
-      let delay = 0;
       const promises: Array<Promise<DownloadResultItem>> = [];
       const semaphore = new Semaphore(this.settings.maxConcurrentDownloads);
       let scheduledPhotoCount = 0;
@@ -1161,7 +1216,6 @@ export class RecNetService extends EventEmitter {
 
         scheduledPhotoCount++;
         const scheduledIndex = scheduledPhotoCount;
-        const scheduledDelayMs = delay;
         promises.push(
           new Promise<DownloadResultItem>((resolve, reject) => {
             void (async () => {
@@ -1170,9 +1224,6 @@ export class RecNetService extends EventEmitter {
               const runStartedAt = Date.now();
               let result: DownloadResultItem | undefined;
               try {
-                if (scheduledDelayMs) {
-                  await this.delay(scheduledDelayMs, operation);
-                }
                 const slotWaitStartedAt = Date.now();
                 await semaphore.acquire();
                 const slotWaitMs = Date.now() - slotWaitStartedAt;
@@ -1181,7 +1232,7 @@ export class RecNetService extends EventEmitter {
                   scheduledIndex,
                   photoId,
                   imageName,
-                  scheduledDelayMs,
+                  scheduledDelayMs: 0,
                   slotWaitMs,
                 });
                 try {
@@ -1256,7 +1307,6 @@ export class RecNetService extends EventEmitter {
             })();
           })
         );
-        delay += this.settings.interPageDelayMs || 0;
       }
       const downloadResults: DownloadResultItem[] =
         await Promise.all<DownloadResultItem>(promises);
@@ -1425,7 +1475,6 @@ export class RecNetService extends EventEmitter {
         0
       );
 
-      let delay = 0;
       const promises: Array<Promise<DownloadResultItem>> = [];
       const semaphore = new Semaphore(this.settings.maxConcurrentDownloads);
       let scheduledPhotoCount = 0;
@@ -1439,7 +1488,6 @@ export class RecNetService extends EventEmitter {
 
         scheduledPhotoCount++;
         const scheduledIndex = scheduledPhotoCount;
-        const scheduledDelayMs = delay;
         promises.push(
           new Promise<DownloadResultItem>((resolve, reject) => {
             void (async () => {
@@ -1448,9 +1496,6 @@ export class RecNetService extends EventEmitter {
               const runStartedAt = Date.now();
               let result: DownloadResultItem | undefined;
               try {
-                if (scheduledDelayMs) {
-                  await this.delay(scheduledDelayMs, operation);
-                }
                 const slotWaitStartedAt = Date.now();
                 await semaphore.acquire();
                 const slotWaitMs = Date.now() - slotWaitStartedAt;
@@ -1459,7 +1504,7 @@ export class RecNetService extends EventEmitter {
                   scheduledIndex,
                   photoId,
                   imageName,
-                  scheduledDelayMs,
+                  scheduledDelayMs: 0,
                   slotWaitMs,
                 });
                 try {
@@ -1534,7 +1579,6 @@ export class RecNetService extends EventEmitter {
             })();
           })
         );
-        delay += this.settings.interPageDelayMs || 0;
       }
       const downloadResults: DownloadResultItem[] =
         await Promise.all<DownloadResultItem>(promises);
@@ -1862,7 +1906,6 @@ export class RecNetService extends EventEmitter {
         0
       );
 
-      let delay = 0;
       const promises: Array<Promise<DownloadResultItem>> = [];
       const semaphore = new Semaphore(this.settings.maxConcurrentDownloads);
       let scheduledPhotoCount = 0;
@@ -1877,7 +1920,6 @@ export class RecNetService extends EventEmitter {
 
         scheduledPhotoCount++;
         const scheduledIndex = scheduledPhotoCount;
-        const scheduledDelayMs = delay;
         promises.push(
           new Promise<DownloadResultItem>((resolve, reject) => {
             void (async () => {
@@ -1887,10 +1929,6 @@ export class RecNetService extends EventEmitter {
               let result: DownloadResultItem | undefined;
 
               try {
-                if (scheduledDelayMs) {
-                  await this.delay(scheduledDelayMs, operation);
-                }
-
                 const slotWaitStartedAt = Date.now();
                 await semaphore.acquire();
                 const slotWaitMs = Date.now() - slotWaitStartedAt;
@@ -1899,7 +1937,7 @@ export class RecNetService extends EventEmitter {
                   scheduledIndex,
                   photoId,
                   imageName,
-                  scheduledDelayMs,
+                  scheduledDelayMs: 0,
                   slotWaitMs,
                 });
 
@@ -1966,7 +2004,6 @@ export class RecNetService extends EventEmitter {
             })();
           })
         );
-        delay += this.settings.interPageDelayMs || 0;
       }
 
       const downloadResults = await Promise.all<DownloadResultItem>(promises);
@@ -3712,6 +3749,7 @@ export class RecNetService extends EventEmitter {
       }
 
       this.settings = { ...DEFAULT_SETTINGS };
+      this.syncHttpClientSettings();
       this.currentOperation = null;
       this.progress = this.createProgressState({
         isRunning: false,

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -91,7 +91,7 @@ const DEFAULT_SETTINGS: RecNetSettings = {
   outputRoot: 'output',
   cdnBase: DEFAULT_CDN_BASE,
   interPageDelayMs: 100,
-  maxConcurrentDownloads: 3
+  maxConcurrentDownloads: 3,
 };
 
 const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
@@ -137,7 +137,7 @@ function normalizeRecNetSettings(input: unknown): RecNetSettings {
     cdnBase: DEFAULT_SETTINGS.cdnBase,
     interPageDelayMs,
     maxPhotosToDownload,
-    maxConcurrentDownloads
+    maxConcurrentDownloads,
   };
 }
 
@@ -261,7 +261,7 @@ export class RecNetService extends EventEmitter {
   }
 
   private syncHttpClientSettings(): void {
-    this.httpClient.setRequestDelayMs(this.settings.interPageDelayMs || 0);
+    this.httpClient.setRequestDelayMs(this.settings.interPageDelayMs || 100);
   }
 
   private getPersistedSettingsForDisk(): PersistedRecNetSettings {
@@ -392,10 +392,7 @@ export class RecNetService extends EventEmitter {
   }
 
   private isOperationCancelledError(error: unknown): boolean {
-    return (
-      error instanceof Error &&
-      error.message === 'Operation cancelled'
-    );
+    return error instanceof Error && error.message === 'Operation cancelled';
   }
 
   private isOutOfDiskSpaceError(error: unknown): boolean {
@@ -603,7 +600,12 @@ export class RecNetService extends EventEmitter {
             operation: () =>
               this.photosController.fetchPlayerPhotos(
                 accountId,
-                { skip, take: PHOTO_MAX_PAGE_SIZE, sort: 2, after: lastSortValue },
+                {
+                  skip,
+                  take: PHOTO_MAX_PAGE_SIZE,
+                  sort: 2,
+                  after: lastSortValue,
+                },
                 token,
                 { signal: operation.controller.signal }
               ),
@@ -1084,7 +1086,10 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadPhotos(accountId: string, token?: string): Promise<DownloadResult> {
+  async downloadPhotos(
+    accountId: string,
+    token?: string
+  ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     const operation = this.startOperation();
 
@@ -1153,7 +1158,8 @@ export class RecNetService extends EventEmitter {
           totalPhotos,
           100,
           {
-            recentActivity: 'Everything in user photos is already on disk for this run.',
+            recentActivity:
+              'Everything in user photos is already on disk for this run.',
           }
         );
         this.setOperationComplete();
@@ -1425,7 +1431,8 @@ export class RecNetService extends EventEmitter {
           totalPhotos,
           100,
           {
-            recentActivity: 'Everything in user feed is already on disk for this run.',
+            recentActivity:
+              'Everything in user feed is already on disk for this run.',
           }
         );
         this.setOperationComplete();
@@ -1828,8 +1835,7 @@ export class RecNetService extends EventEmitter {
       const existingFiles = (await fs.readdir(profileHistoryDir)).filter(file =>
         file.toLowerCase().endsWith('.jpg')
       ).length;
-      let remainingDownloadSlots =
-        (maxPhotosToDownload || 0) - existingFiles;
+      let remainingDownloadSlots = (maxPhotosToDownload || 0) - existingFiles;
 
       if (hasDownloadLimit && remainingDownloadSlots <= 0) {
         this.updateSourceProgress(
@@ -2333,7 +2339,9 @@ export class RecNetService extends EventEmitter {
         Description: photo.Description ?? '',
         PlayerId: this.normalizeId(photo.PlayerId) || normalizedAccountId,
         TaggedPlayerIds: Array.isArray(photo.TaggedPlayerIds)
-          ? photo.TaggedPlayerIds.map(id => this.normalizeId(id)).filter(Boolean)
+          ? photo.TaggedPlayerIds.map(id => this.normalizeId(id)).filter(
+              Boolean
+            )
           : [],
         RoomId: this.normalizeId(photo.RoomId),
         PlayerEventId: this.normalizeId(photo.PlayerEventId) || undefined,
@@ -3492,7 +3500,10 @@ export class RecNetService extends EventEmitter {
       const feedInfo = await this.readImageDirectoryInfo(feedDir);
       const isOnDisk = (photo: Photo): boolean => {
         const photoId = this.normalizeId(photo.Id);
-        return !!photoId && (photosInfo.ids.has(photoId) || feedInfo.ids.has(photoId));
+        return (
+          !!photoId &&
+          (photosInfo.ids.has(photoId) || feedInfo.ids.has(photoId))
+        );
       };
       const alreadyOnDisk = metadata.filter(isOnDisk).length;
       const remainingToDownload = Math.max(0, metadata.length - alreadyOnDisk);
@@ -3521,7 +3532,10 @@ export class RecNetService extends EventEmitter {
       const photosInfo = await this.readImageDirectoryInfo(photosDir);
       const isOnDisk = (photo: Photo): boolean => {
         const photoId = this.normalizeId(photo.Id);
-        return !!photoId && (feedInfo.ids.has(photoId) || photosInfo.ids.has(photoId));
+        return (
+          !!photoId &&
+          (feedInfo.ids.has(photoId) || photosInfo.ids.has(photoId))
+        );
       };
       const alreadyOnDisk = metadata.filter(isOnDisk).length;
       const remainingToDownload = Math.max(0, metadata.length - alreadyOnDisk);
@@ -3541,10 +3555,16 @@ export class RecNetService extends EventEmitter {
       };
     }
 
-    const metadataPath = path.join(accountDir, `${accountId}_profile_history.json`);
+    const metadataPath = path.join(
+      accountDir,
+      `${accountId}_profile_history.json`
+    );
     const profileHistoryDir = path.join(accountDir, 'profile-history');
     const manifestPayload = await this.readProfileHistoryManifest(metadataPath);
-    const metadata = this.normalizeProfileHistoryPhotos(manifestPayload, accountId);
+    const metadata = this.normalizeProfileHistoryPhotos(
+      manifestPayload,
+      accountId
+    );
     const directoryInfo = await this.readImageDirectoryInfo(profileHistoryDir);
     const alreadyOnDisk = metadata.filter(photo => {
       const photoId = this.normalizeId(photo.Id);
@@ -3579,7 +3599,9 @@ export class RecNetService extends EventEmitter {
       return [];
     }
 
-    const payload = (await fs.readJson(metadataPath)) as ProfileHistoryImageDto[];
+    const payload = (await fs.readJson(
+      metadataPath
+    )) as ProfileHistoryImageDto[];
     return Array.isArray(payload) ? payload : [];
   }
 
@@ -3913,10 +3935,7 @@ export class RecNetService extends EventEmitter {
             const profileHistory: Photo[] = await fs.readJson(
               profileHistoryJsonPath
             );
-            if (
-              Array.isArray(profileHistory) &&
-              profileHistory.length > 0
-            ) {
+            if (Array.isArray(profileHistory) && profileHistory.length > 0) {
               hasProfileHistory = true;
               profileHistoryCount = profileHistory.length;
             }

--- a/src/main/services/recnet/__tests__/http-client.test.ts
+++ b/src/main/services/recnet/__tests__/http-client.test.ts
@@ -1,0 +1,80 @@
+import { axiosRequest } from '../../../utils/axiosRequest';
+import { RecNetHttpClient } from '../http-client';
+
+jest.mock('../../../utils/axiosRequest', () => ({
+  axiosRequest: jest.fn(),
+}));
+
+const mockAxiosRequest = axiosRequest as jest.MockedFunction<typeof axiosRequest>;
+
+describe('RecNetHttpClient', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-06T12:00:00.000Z'));
+    mockAxiosRequest.mockReset();
+    mockAxiosRequest.mockResolvedValue({
+      success: true,
+      value: { ok: true },
+      status: 200,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('enforces the configured delay between request starts', async () => {
+    const requestTimes: number[] = [];
+    mockAxiosRequest.mockImplementation(async config => {
+      requestTimes.push(Date.now());
+      return {
+        success: true,
+        value: config.url ?? 'ok',
+        status: 200,
+      };
+    });
+
+    const client = new RecNetHttpClient();
+    client.setRequestDelayMs(100);
+
+    const firstRequest = client.request({ url: 'https://example.com/first' });
+    const secondRequest = client.request({ url: 'https://example.com/second' });
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(mockAxiosRequest).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(99);
+    expect(mockAxiosRequest).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await Promise.all([firstRequest, secondRequest]);
+
+    expect(mockAxiosRequest).toHaveBeenCalledTimes(2);
+    expect(requestTimes).toHaveLength(2);
+    expect(requestTimes[1] - requestTimes[0]).toBe(100);
+  });
+
+  it('cancels a delayed request before it reaches the transport', async () => {
+    const client = new RecNetHttpClient();
+    client.setRequestDelayMs(100);
+
+    const firstRequest = client.request({ url: 'https://example.com/first' });
+    const controller = new AbortController();
+    const secondRequest = client.request(
+      { url: 'https://example.com/second' },
+      undefined,
+      { signal: controller.signal }
+    );
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(mockAxiosRequest).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(50);
+    controller.abort();
+
+    await expect(secondRequest).rejects.toThrow('Operation cancelled');
+    await firstRequest;
+
+    expect(mockAxiosRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/services/recnet/accounts-controller.ts
+++ b/src/main/services/recnet/accounts-controller.ts
@@ -56,10 +56,6 @@ export class AccountsController {
           `Failed to fetch batch of accounts: ${(error as Error).message}`
         );
       }
-
-      if (i + batchSize < accountIds.length) {
-        await this.delayBetweenBatches(options?.signal);
-      }
     }
 
     return results;
@@ -112,27 +108,6 @@ export class AccountsController {
     );
     return this.normalizeAccounts(accounts);
   }
-
-  private delayBetweenBatches(signal?: AbortSignal): Promise<void> {
-    if (signal?.aborted) {
-      return Promise.reject(new Error('Operation cancelled'));
-    }
-
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        signal?.removeEventListener('abort', onAbort);
-        resolve();
-      }, 100);
-
-      const onAbort = () => {
-        clearTimeout(timeout);
-        reject(new Error('Operation cancelled'));
-      };
-
-      signal?.addEventListener('abort', onAbort, { once: true });
-    });
-  }
-
   private normalizeAccounts(accounts: PlayerResult[]): PlayerResult[] {
     return accounts.map(account => this.normalizeAccount(account));
   }

--- a/src/main/services/recnet/events-controller.ts
+++ b/src/main/services/recnet/events-controller.ts
@@ -56,32 +56,8 @@ export class EventsController {
           `Failed to fetch batch of events: ${(error as Error).message}`
         );
       }
-
-      if (i + batchSize < eventIds.length) {
-        await this.delayBetweenBatches(options?.signal);
-      }
     }
 
     return results;
-  }
-
-  private delayBetweenBatches(signal?: AbortSignal): Promise<void> {
-    if (signal?.aborted) {
-      return Promise.reject(new Error('Operation cancelled'));
-    }
-
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        signal?.removeEventListener('abort', onAbort);
-        resolve();
-      }, 100);
-
-      const onAbort = () => {
-        clearTimeout(timeout);
-        reject(new Error('Operation cancelled'));
-      };
-
-      signal?.addEventListener('abort', onAbort, { once: true });
-    });
   }
 }

--- a/src/main/services/recnet/http-client.ts
+++ b/src/main/services/recnet/http-client.ts
@@ -12,6 +12,19 @@ export interface RecNetRequestOptions {
 }
 
 export class RecNetHttpClient {
+  private requestDelayMs = 0;
+  private lastRequestStartedAt = 0;
+  private throttleQueue: Promise<void> = Promise.resolve();
+
+  setRequestDelayMs(delayMs: number): void {
+    if (!Number.isFinite(delayMs)) {
+      this.requestDelayMs = 0;
+      return;
+    }
+
+    this.requestDelayMs = Math.max(0, Math.floor(delayMs));
+  }
+
   private buildRequestConfig(
     config: AxiosRequestConfig,
     token?: string,
@@ -39,6 +52,7 @@ export class RecNetHttpClient {
     token?: string,
     options?: RecNetRequestOptions
   ): Promise<GenericResponse<T>> {
+    await this.waitForRequestSlot(config, options?.signal);
     return axiosRequest<T>(this.buildRequestConfig(config, token, options));
   }
 
@@ -68,5 +82,80 @@ export class RecNetHttpClient {
     }
 
     return response.value;
+  }
+
+  private async waitForRequestSlot(
+    config: AxiosRequestConfig,
+    signal?: AbortSignal
+  ): Promise<void> {
+    let releaseQueue: (() => void) | undefined;
+    const previousQueue = this.throttleQueue;
+    this.throttleQueue = new Promise<void>(resolve => {
+      releaseQueue = resolve;
+    });
+
+    try {
+      await previousQueue;
+
+      if (signal?.aborted) {
+        throw new Error('Operation cancelled');
+      }
+
+      const requestLabel = this.describeRequest(config);
+      const delayMs = this.requestDelayMs;
+      const previousRequestStartedAt = this.lastRequestStartedAt;
+      if (delayMs > 0 && previousRequestStartedAt > 0) {
+        const elapsedMs = Date.now() - previousRequestStartedAt;
+        const waitMs = Math.max(0, delayMs - elapsedMs);
+        if (waitMs > 0) {
+          console.log(
+            `[RecNetHttpClient] request-wait ${requestLabel} waitMs=${waitMs} configuredDelayMs=${delayMs} elapsedSincePreviousStartMs=${elapsedMs}`
+          );
+          await this.delay(waitMs, signal);
+        }
+      }
+
+      const startedAt = Date.now();
+      const sincePreviousStartMs =
+        previousRequestStartedAt > 0 ? startedAt - previousRequestStartedAt : -1;
+      this.lastRequestStartedAt = startedAt;
+      console.log(
+        `[RecNetHttpClient] request-start ${requestLabel} configuredDelayMs=${delayMs} sincePreviousStartMs=${
+          sincePreviousStartMs >= 0 ? sincePreviousStartMs : 'first'
+        }`
+      );
+    } finally {
+      releaseQueue?.();
+    }
+  }
+
+  private describeRequest(config: AxiosRequestConfig): string {
+    const method = (config.method || 'GET').toUpperCase();
+    const url = config.url || '(unknown-url)';
+    return `${method} ${url}`;
+  }
+
+  private delay(ms: number, signal?: AbortSignal): Promise<void> {
+    if (ms <= 0) {
+      return Promise.resolve();
+    }
+
+    if (signal?.aborted) {
+      return Promise.reject(new Error('Operation cancelled'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+
+      const onAbort = () => {
+        clearTimeout(timeout);
+        reject(new Error('Operation cancelled'));
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 }

--- a/src/main/services/recnet/rooms-controller.ts
+++ b/src/main/services/recnet/rooms-controller.ts
@@ -62,32 +62,8 @@ export class RoomsController {
           `Failed to fetch batch of rooms: ${(error as Error).message}`
         );
       }
-
-      if (i + batchSize < roomIds.length) {
-        await this.delayBetweenBatches(options?.signal);
-      }
     }
 
     return results;
-  }
-
-  private delayBetweenBatches(signal?: AbortSignal): Promise<void> {
-    if (signal?.aborted) {
-      return Promise.reject(new Error('Operation cancelled'));
-    }
-
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        signal?.removeEventListener('abort', onAbort);
-        resolve();
-      }, 100);
-
-      const onAbort = () => {
-        clearTimeout(timeout);
-        reject(new Error('Operation cancelled'));
-      };
-
-      signal?.addEventListener('abort', onAbort, { once: true });
-    });
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -54,8 +54,8 @@ function App() {
   const [settings, setSettings] = useState<RecNetSettings>({
     outputRoot: 'output',
     cdnBase: DEFAULT_CDN_BASE,
-    interPageDelayMs: 0,
-    maxConcurrentDownloads: 30,
+    interPageDelayMs: 100,
+    maxConcurrentDownloads: 3,
   });
 
   const [progress, setProgress] = useState<Progress>({

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -49,7 +49,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const handleDelayChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.trim();
     if (value === '') {
-      await onUpdateSettings({ interPageDelayMs: 0 });
+      await onUpdateSettings({ interPageDelayMs: 100 });
     } else {
       const numValue = parseInt(value);
       if (!isNaN(numValue)) {
@@ -62,7 +62,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const handleMaxConcurrentChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.trim();
     if (value === '') {
-      await onUpdateSettings({ maxConcurrentDownloads: 30 });
+      await onUpdateSettings({ maxConcurrentDownloads: 3 });
     } else {
       const numValue = parseInt(value);
       if (!isNaN(numValue)) {
@@ -123,6 +123,9 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
         {/* Delay Between Pages */}
         <div className="space-y-2">
           <Label htmlFor="request-delay">Request Delay (ms)</Label>
+          <p className="text-xs text-muted-foreground">
+            Resets to 100 when the app is closed and reopened.
+          </p>
           <Input
             id="request-delay"
             type="number"
@@ -139,6 +142,9 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
         {/* Concurrent Downloads */}
         <div className="space-y-2">
           <Label htmlFor="concurrent-downloads">Max Concurrent Downloads</Label>
+          <p className="text-xs text-muted-foreground">
+            Resets to 3 when the app is closed and reopened.
+          </p>
           <Input
             id="concurrent-downloads"
             type="number"


### PR DESCRIPTION
- Updated concurrent downloads to default 3 (prev. 30)
- Updated rate limit to 100ms (prev. 0)
- These settings are no longer saved/loaded from disk. They are reset each time the application is closed and reopened.

- All API requests now follow the rate limiting strictly