### PR TITLE
swap to viewer only mode on june 2nd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rr-image-downloader",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "description": "RR Image Downloader - Download Rec Room user images.",
   "main": "dist/main/main/main.js",
   "homepage": "./",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,10 +36,22 @@ import {
 import type { DownloadSourceSelection } from '../shared/download-sources';
 import { EventDto } from './models/EventDto';
 import { ImageCommentDto } from './models/ImageCommentDto';
+import {
+  isViewerOnlyMode,
+  VIEWER_ONLY_MODE_ERROR,
+} from '../shared/viewer-only-mode';
 
 // Keep a global reference of the window object
 let mainWindow: BrowserWindow | null = null;
 let recNetService: RecNetService;
+
+function getViewerOnlyNetworkError(): string | null {
+  return isViewerOnlyMode() ? VIEWER_ONLY_MODE_ERROR : null;
+}
+
+function viewerOnlyApiResponse<T>(): ApiResponse<T> {
+  return { success: false, error: VIEWER_ONLY_MODE_ERROR };
+}
 const isDev = process.argv.includes('--dev');
 
 const MAIN_WINDOW_MIN_WIDTH = 850;
@@ -344,6 +356,11 @@ function registerLocalFileProtocol() {
 
 // Setup auto-updater event handlers
 function setupAutoUpdater() {
+  if (isViewerOnlyMode()) {
+    console.log('Auto-updater disabled in viewer-only mode');
+    return;
+  }
+
   if (isDev) {
     console.log('Auto-updater disabled in development mode');
     return;
@@ -459,6 +476,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: CollectPhotosParams
   ): Promise<ApiResponse<CollectionResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -487,6 +507,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: CollectFeedPhotosParams
   ): Promise<ApiResponse<CollectionResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -516,6 +539,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: ValidateProfileHistoryAccessParams & { accountId: string }
   ): Promise<ApiResponse<ProfileHistoryCollectionResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -538,6 +564,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: BuildDownloadPreflightParams
   ): Promise<ApiResponse<DownloadPreflightSummary>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -560,6 +589,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -582,6 +614,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: DownloadPhotosParams
   ): Promise<ApiResponse<DownloadResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -604,6 +639,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: ValidateProfileHistoryAccessParams & { accountId: string }
   ): Promise<ApiResponse<DownloadResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -626,6 +664,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: LookupRoomParams
   ): Promise<ApiResponse<RoomDto>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const result = await recNetService.lookupRoomByName(
         params.roomName,
@@ -644,6 +685,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: DownloadRoomPhotoBatchParams
   ): Promise<ApiResponse<RoomPhotoBatchResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -663,6 +707,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: DiscoverEventsForUsernameParams
   ): Promise<ApiResponse<EventDiscoveryResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -686,6 +733,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: DownloadEventPhotosParams
   ): Promise<ApiResponse<EventPhotoBatchResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const outputErr = await getOutputWriteBlockedError();
       if (outputErr) {
@@ -705,6 +755,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     params: ValidateProfileHistoryAccessParams
   ): Promise<ApiResponse<ProfileHistoryAccessResult>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const result = await recNetService.validateProfileHistoryAccess(
         params.username,
@@ -793,6 +846,9 @@ ipcMain.handle(
     event: IpcMainInvokeEvent,
     accountId: string
   ): Promise<ApiResponse<AccountInfo>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const result = await recNetService.lookupAccountById(accountId);
       return { success: true, data: result };
@@ -810,6 +866,9 @@ ipcMain.handle(
     username: string,
     token?: string
   ): Promise<ApiResponse<AccountInfo>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const result = await recNetService.lookupAccountByUsername(username, token);
       return { success: true, data: result };
@@ -842,6 +901,9 @@ ipcMain.handle(
     username: string,
     token?: string
   ): Promise<ApiResponse<AccountInfo[]>> => {
+    if (getViewerOnlyNetworkError()) {
+      return viewerOnlyApiResponse();
+    }
     try {
       const result = token
         ? await recNetService.searchAccounts(username, token)
@@ -1659,6 +1721,9 @@ const ALLOWED_EXTERNAL_URL_PREFIXES = [
 ipcMain.handle(
   'open-external',
   async (event: IpcMainInvokeEvent, url: string): Promise<void> => {
+    if (getViewerOnlyNetworkError()) {
+      throw new Error(VIEWER_ONLY_MODE_ERROR);
+    }
     let parsed: URL;
     try {
       parsed = new URL(url);
@@ -1709,6 +1774,9 @@ ipcMain.handle(
 
 // Auto-updater IPC handlers
 ipcMain.handle('check-for-updates', async (): Promise<void> => {
+  if (getViewerOnlyNetworkError()) {
+    throw new Error(VIEWER_ONLY_MODE_ERROR);
+  }
   if (!isDev) {
     try {
       await autoUpdater.checkForUpdates();
@@ -1720,6 +1788,9 @@ ipcMain.handle('check-for-updates', async (): Promise<void> => {
 });
 
 ipcMain.handle('download-update', async (): Promise<void> => {
+  if (getViewerOnlyNetworkError()) {
+    throw new Error(VIEWER_ONLY_MODE_ERROR);
+  }
   if (!isDev) {
     try {
       await autoUpdater.downloadUpdate();
@@ -1731,6 +1802,9 @@ ipcMain.handle('download-update', async (): Promise<void> => {
 });
 
 ipcMain.handle('install-update', async (): Promise<void> => {
+  if (getViewerOnlyNetworkError()) {
+    throw new Error(VIEWER_ONLY_MODE_ERROR);
+  }
   if (!isDev) {
     autoUpdater.quitAndInstall(false, true);
   }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,6 +39,10 @@ import {
   buildDownloadProgressIncident,
   getDownloadProgressLogEntries,
 } from './utils/downloadProgressFeedback';
+import {
+  getViewerOnlyCutoffDate,
+  isViewerOnlyMode,
+} from '../shared/viewer-only-mode';
 
 interface DownloadRequestState {
   username: string;
@@ -62,11 +66,15 @@ interface PendingDownloadPreflight {
 const EMPTY_DOWNLOAD_STEP = 'Nothing to download';
 const CLEAN_DOWNLOAD_FOLLOW_UP =
   'If you take more photos in Rec Room, come back and run this download again. The app will only grab anything new.';
+const VIEWER_ONLY_RECHECK_MS = 60 * 60 * 1000;
 
 /** Set to true to allow starting a library move from the debug menu. */
 const LIBRARY_MOVE_ENABLED = false;
 
 function App() {
+  const [viewerOnlyMode, setViewerOnlyMode] = useState(() =>
+    isViewerOnlyMode()
+  );
   const [settings, setSettings] = useState<RecNetSettings>({
     outputRoot: '',
     cdnBase: DEFAULT_CDN_BASE,
@@ -138,6 +146,29 @@ function App() {
     loadSettings();
     setupProgressMonitoring();
   }, []);
+
+  useEffect(() => {
+    if (viewerOnlyMode) {
+      setDownloadPanelOpen(false);
+      setPendingPreflight(null);
+      if (isDownloading) {
+        void window.electronAPI?.cancelOperation?.();
+      }
+      return;
+    }
+
+    const delayMs = Math.min(
+      Math.max(getViewerOnlyCutoffDate().getTime() - Date.now(), 0),
+      VIEWER_ONLY_RECHECK_MS
+    );
+    const timeout = window.setTimeout(() => {
+      setViewerOnlyMode(isViewerOnlyMode());
+      setDownloadPanelOpen(false);
+      setPendingPreflight(null);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [isDownloading, viewerOnlyMode]);
 
   useEffect(() => {
     if (progress.isRunning) {
@@ -372,7 +403,8 @@ function App() {
 
   const retryRequest = downloadDraft ?? lastDownloadRequest;
   const canRetryDownload = Boolean(
-    retryRequest?.filePath.trim() &&
+    !viewerOnlyMode &&
+      retryRequest?.filePath.trim() &&
       (() => {
         const r = retryRequest;
         if (!r) return false;
@@ -440,6 +472,10 @@ function App() {
     eventIds: string[] = [],
     knownCreatorAccountId?: string
   ) => {
+    if (viewerOnlyMode) {
+      return;
+    }
+
     const selectedSources = getSelectedDownloadSources(downloadSources);
     const trimmedUser = username.trim();
     const trimmedCreator = knownCreatorAccountId?.trim();
@@ -919,7 +955,7 @@ function App() {
   };
 
   const handleConfirmDownload = useCallback(async () => {
-    if (!pendingPreflight || !window.electronAPI) {
+    if (viewerOnlyMode || !pendingPreflight || !window.electronAPI) {
       return;
     }
 
@@ -1083,6 +1119,7 @@ function App() {
     pendingPreflight,
     reportDownloadResult,
     setCleanCompletionProgress,
+    viewerOnlyMode,
   ]);
 
   const handleSkipDownload = useCallback(() => {
@@ -1099,7 +1136,7 @@ function App() {
   }, [addLog, pendingPreflight, setCleanCompletionProgress]);
 
   const handleRetryDownload = useCallback(async () => {
-    if (!retryRequest || isDownloading) {
+    if (viewerOnlyMode || !retryRequest || isDownloading) {
       return;
     }
 
@@ -1114,23 +1151,26 @@ function App() {
       retryRequest.eventIds ?? [],
       retryRequest.knownCreatorAccountId
     );
-  }, [handleDownload, isDownloading, retryRequest]);
+  }, [handleDownload, isDownloading, retryRequest, viewerOnlyMode]);
 
   const openDownloadPanelPlain = useCallback(() => {
+    if (viewerOnlyMode) {
+      return;
+    }
     setEventDownloadPanelPrefill(null);
     setDownloadPanelOpen(true);
-  }, []);
+  }, [viewerOnlyMode]);
 
   const handleDownloadPanelOpenChange = useCallback((nextOpen: boolean) => {
-    setDownloadPanelOpen(nextOpen);
+    setDownloadPanelOpen(viewerOnlyMode ? false : nextOpen);
     if (!nextOpen) {
       setEventDownloadPanelPrefill(null);
     }
-  }, []);
+  }, [viewerOnlyMode]);
 
   const startQuickEventPhotoDownload = useCallback(
     async (intent: EventDownloadIntent) => {
-      if (!window.electronAPI || intent.kind !== 'eventAlbum') {
+      if (viewerOnlyMode || !window.electronAPI || intent.kind !== 'eventAlbum') {
         return;
       }
       const filePath = settings.outputRoot || '';
@@ -1159,11 +1199,15 @@ function App() {
       handleDownload,
       settings.outputPathConfiguredForDownload,
       settings.outputRoot,
+      viewerOnlyMode,
     ]
   );
 
   const handleOpenDownloadPanelFromViewer = useCallback(
     (intent?: EventDownloadIntent) => {
+      if (viewerOnlyMode) {
+        return;
+      }
       if (intent?.kind === 'eventAlbum') {
         if (settings.outputPathConfiguredForDownload) {
           void startQuickEventPhotoDownload(intent);
@@ -1183,6 +1227,7 @@ function App() {
       openDownloadPanelPlain,
       settings.outputPathConfiguredForDownload,
       startQuickEventPhotoDownload,
+      viewerOnlyMode,
     ]
   );
 
@@ -1294,7 +1339,7 @@ function App() {
         />
 
         <CustomTitleBar
-          onDownloadClick={openDownloadPanelPlain}
+          onDownloadClick={viewerOnlyMode ? undefined : openDownloadPanelPlain}
           onStatsClick={() => setStatsDialogOpen(true)}
           settings={settings}
           onUpdateSettings={updateSettings}
@@ -1305,16 +1350,17 @@ function App() {
           debugMenuOpen={debugMenuOpen}
           onDebugMenuOpenChange={setDebugMenuOpen}
           resultsScrollRequestId={resultsScrollRequestId}
-          onRetryDownload={handleRetryDownload}
-          canRetryDownload={canRetryDownload}
+          onRetryDownload={viewerOnlyMode ? undefined : handleRetryDownload}
+          canRetryDownload={!viewerOnlyMode && canRetryDownload}
           isRetryingDownload={isDownloading}
-          onOpenDownloadPanel={openDownloadPanelPlain}
+          onOpenDownloadPanel={viewerOnlyMode ? undefined : openDownloadPanelPlain}
           onOpenOutputFolder={handleOpenPathInExplorer}
           outputExplorerPath={effectiveOutputExplorerPath}
           libraryMode={libraryMode}
           onLibraryModeChange={setLibraryMode}
           libraryMoveEnabled={LIBRARY_MOVE_ENABLED}
           onOpenLibraryMove={() => setLibraryMoveDialogOpen(true)}
+          viewerOnlyMode={viewerOnlyMode}
         />
 
         <div className="container mx-auto px-4 py-4 max-w-7xl h-screen flex flex-col overflow-hidden pt-14">
@@ -1322,34 +1368,36 @@ function App() {
             incident={activeIncident}
             outputExplorerPath={effectiveOutputExplorerPath}
             onDismiss={dismissIncident}
-            onRetryDownload={handleRetryDownload}
-            canRetryDownload={canRetryDownload}
+            onRetryDownload={viewerOnlyMode ? undefined : handleRetryDownload}
+            canRetryDownload={!viewerOnlyMode && canRetryDownload}
             isRetrying={isDownloading}
-            onOpenDownloadPanel={openDownloadPanelPlain}
+            onOpenDownloadPanel={viewerOnlyMode ? undefined : openDownloadPanelPlain}
             onOpenOperationResults={openOperationResults}
             onOpenPathInExplorer={handleOpenPathInExplorer}
           />
           {/* Header space removed - using custom title bar instead */}
 
           {/* Download Panel Modal */}
-          <ErrorBoundary sectionName="Download panel">
-            <DownloadPanel
-              open={downloadPanelOpen}
-              onOpenChange={handleDownloadPanelOpenChange}
-              onDownload={handleDownload}
-              onDraftChange={handleDownloadDraftChange}
-              onCancel={handleCancelDownload}
-              isDownloading={isDownloading || !!pendingPreflight}
-              showCancel={isDownloading}
-              settings={settings}
-              libraryMode={libraryMode}
-              onUpdateSettings={updateSettings}
-              eventDownloadPrefill={eventDownloadPanelPrefill}
-              onEventDownloadPrefillConsumed={() =>
-                setEventDownloadPanelPrefill(null)
-              }
-            />
-          </ErrorBoundary>
+          {!viewerOnlyMode && (
+            <ErrorBoundary sectionName="Download panel">
+              <DownloadPanel
+                open={downloadPanelOpen}
+                onOpenChange={handleDownloadPanelOpenChange}
+                onDownload={handleDownload}
+                onDraftChange={handleDownloadDraftChange}
+                onCancel={handleCancelDownload}
+                isDownloading={isDownloading || !!pendingPreflight}
+                showCancel={isDownloading}
+                settings={settings}
+                libraryMode={libraryMode}
+                onUpdateSettings={updateSettings}
+                eventDownloadPrefill={eventDownloadPanelPrefill}
+                onEventDownloadPrefillConsumed={() =>
+                  setEventDownloadPanelPrefill(null)
+                }
+              />
+            </ErrorBoundary>
+          )}
 
           {/* Stats Dialog */}
           <ErrorBoundary sectionName="Stats">
@@ -1368,12 +1416,18 @@ function App() {
                 progress={progress}
                 onClose={() => setShowProgressPanel(false)}
                 onOpenOperationResults={openOperationResults}
-                onOpenDownloadPanel={openDownloadPanelPlain}
+                onOpenDownloadPanel={
+                  viewerOnlyMode ? undefined : openDownloadPanelPlain
+                }
                 onCancelDownload={handleCancelDownload}
-                onConfirmDownload={handleConfirmDownload}
+                onConfirmDownload={
+                  viewerOnlyMode ? undefined : handleConfirmDownload
+                }
                 onSkipDownload={handleSkipDownload}
-                onRetryDownload={handleRetryDownload}
-                canRetryDownload={canRetryDownload}
+                onRetryDownload={
+                  viewerOnlyMode ? undefined : handleRetryDownload
+                }
+                canRetryDownload={!viewerOnlyMode && canRetryDownload}
                 isRetrying={isDownloading}
               />
             </div>
@@ -1413,11 +1467,16 @@ function App() {
                 scrollContainerRef={photoScrollRef}
                 headerMode={headerMode}
                 onOpenActivityMenu={handleOpenActivityMenu}
-                onOpenDownloadPanel={handleOpenDownloadPanelFromViewer}
+                onOpenDownloadPanel={
+                  viewerOnlyMode
+                    ? undefined
+                    : handleOpenDownloadPanelFromViewer
+                }
                 onRevealOutputFolder={handleRevealOutputFolder}
                 onPhotosLoadError={handlePhotosLoadError}
                 onPhotosLoadSuccess={clearPhotosIncident}
                 cdnBase={settings.cdnBase}
+                viewerOnlyMode={viewerOnlyMode}
               />
             </ErrorBoundary>
           </div>

--- a/src/renderer/components/CustomTitleBar.tsx
+++ b/src/renderer/components/CustomTitleBar.tsx
@@ -24,7 +24,7 @@ import {
 } from './ui/select';
 
 interface CustomTitleBarProps {
-  onDownloadClick: () => void;
+  onDownloadClick?: () => void;
   onStatsClick: () => void;
   settings: RecNetSettings;
   onUpdateSettings: (settings: Partial<RecNetSettings>) => Promise<void>;
@@ -56,6 +56,7 @@ interface CustomTitleBarProps {
   /** When false, the library move row is shown but the button stays disabled. */
   libraryMoveEnabled?: boolean;
   onOpenLibraryMove?: () => void;
+  viewerOnlyMode?: boolean;
 }
 
 export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
@@ -80,6 +81,7 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
   onLibraryModeChange,
   libraryMoveEnabled = false,
   onOpenLibraryMove,
+  viewerOnlyMode = false,
 }) => {
   const [isMaximized, setIsMaximized] = useState(false);
   const resultsSectionRef = useRef<HTMLDivElement | null>(null);
@@ -192,16 +194,18 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
             >
               <BarChart3 className="h-4 w-4" />
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={onDownloadClick}
-              aria-label="Download"
-            >
-              <Download className="h-4 w-4" />
-            </Button>
-            <UpdateIndicator />
+            {onDownloadClick && !viewerOnlyMode && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={onDownloadClick}
+                aria-label="Download"
+              >
+                <Download className="h-4 w-4" />
+              </Button>
+            )}
+            {!viewerOnlyMode && <UpdateIndicator />}
             <Button
               variant="ghost"
               size="icon"

--- a/src/renderer/components/EventCoverImage.tsx
+++ b/src/renderer/components/EventCoverImage.tsx
@@ -8,6 +8,7 @@ interface EventCoverImageProps {
   cdnBase?: string;
   className?: string;
   iconClassName?: string;
+  allowRemoteFallback?: boolean;
 }
 
 export const EventCoverImage: React.FC<EventCoverImageProps> = ({
@@ -15,6 +16,7 @@ export const EventCoverImage: React.FC<EventCoverImageProps> = ({
   cdnBase = DEFAULT_CDN_BASE,
   className = 'h-full w-full object-cover',
   iconClassName = 'h-8 w-8',
+  allowRemoteFallback = true,
 }) => {
   const sources = useMemo(() => {
     const nextSources: string[] = [];
@@ -24,7 +26,7 @@ export const EventCoverImage: React.FC<EventCoverImageProps> = ({
     }
 
     const imageName = event.imageName?.trim();
-    if (imageName && imageName.toLowerCase() !== 'null') {
+    if (allowRemoteFallback && imageName && imageName.toLowerCase() !== 'null') {
       const cdnUrl = buildCdnImageUrl(cdnBase, imageName);
       if (cdnUrl && !nextSources.includes(cdnUrl)) {
         nextSources.push(cdnUrl);
@@ -32,7 +34,7 @@ export const EventCoverImage: React.FC<EventCoverImageProps> = ({
     }
 
     return nextSources;
-  }, [cdnBase, event.imageName, event.localImagePath]);
+  }, [allowRemoteFallback, cdnBase, event.imageName, event.localImagePath]);
 
   const [sourceIndex, setSourceIndex] = useState(0);
 

--- a/src/renderer/components/PhotoDetailModal.tsx
+++ b/src/renderer/components/PhotoDetailModal.tsx
@@ -35,6 +35,7 @@ interface PhotoDetailModalProps {
   eventMap?: Map<string, string>;
   cdnBase?: string;
   imageComments?: ImageCommentDto[];
+  allowRemoteImages?: boolean;
 }
 
 type OptionalElectronAPI = {
@@ -54,9 +55,17 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   eventMap = new Map(),
   cdnBase = DEFAULT_CDN_BASE,
   imageComments = [],
+  allowRemoteImages = true,
 }) => {
   const { getPhotoRoom, getPhotoTaggedUsers, getPhotoImageUrl, getPhotoEvent } =
-    usePhotoMetadata(roomMap, accountMap, eventMap, cdnBase, usernameMap);
+    usePhotoMetadata(
+      roomMap,
+      accountMap,
+      eventMap,
+      cdnBase,
+      usernameMap,
+      allowRemoteImages
+    );
   const { isFavorite, toggleFavorite } = useFavorites();
   const electronAPI = (window as Window & { electronAPI?: OptionalElectronAPI })
     .electronAPI;
@@ -350,20 +359,22 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
             <div className="pt-2 border-t text-sm text-muted-foreground">
               <p>Photo ID: {photo.Id}</p>
               {photo.ImageName && <p>Image: {photo.ImageName}</p>}
-              <p>
-                URL:
-                <button
-                  className="text-blue-500 hover:text-blue-600 underline ml-1 cursor-pointer"
-                  onClick={() => {
-                    const url = `https://rec.net/image/${photo.Id}`;
-                    if (electronAPI) {
-                      void electronAPI.openExternal?.(url);
-                    }
-                  }}
-                >
-                  https://rec.net/image/{photo.Id}
-                </button>
-              </p>
+              {allowRemoteImages && (
+                <p>
+                  URL:
+                  <button
+                    className="text-blue-500 hover:text-blue-600 underline ml-1 cursor-pointer"
+                    onClick={() => {
+                      const url = `https://rec.net/image/${photo.Id}`;
+                      if (electronAPI) {
+                        void electronAPI.openExternal?.(url);
+                      }
+                    }}
+                  >
+                    https://rec.net/image/{photo.Id}
+                  </button>
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/src/renderer/components/PhotoGrid.tsx
+++ b/src/renderer/components/PhotoGrid.tsx
@@ -30,6 +30,7 @@ interface PhotoGridProps {
   onScrollPositionChange?: (scrollTop: number) => void;
   className?: string;
   accountId?: string;
+  allowRemoteImages?: boolean;
 }
 
 const PhotoGridComponent: React.FC<PhotoGridProps> = ({
@@ -46,10 +47,18 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
   onScrollPositionChange,
   className = '',
   accountId,
+  allowRemoteImages = true,
 }) => {
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const { getPhotoRoom, getPhotoUsers, getPhotoImageUrl, getPhotoEvent } =
-    usePhotoMetadata(roomMap, accountMap, eventMap, cdnBase);
+    usePhotoMetadata(
+      roomMap,
+      accountMap,
+      eventMap,
+      cdnBase,
+      undefined,
+      allowRemoteImages
+    );
   const internalScrollRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = scrollContainerRefProp ?? internalScrollRef;
   const [containerSize, setContainerSize] = useState({ width: 0, height: 700 });

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -64,6 +64,7 @@ interface PhotoViewerProps {
   onPhotosLoadError?: (message: string) => void;
   onPhotosLoadSuccess?: () => void;
   cdnBase?: string;
+  viewerOnlyMode?: boolean;
 }
 
 type PhotoSource = 'photos' | 'feed' | 'profile-history';
@@ -87,6 +88,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   onPhotosLoadError,
   onPhotosLoadSuccess,
   cdnBase = DEFAULT_CDN_BASE,
+  viewerOnlyMode = false,
 }) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -1136,7 +1138,11 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
             </div>
           ) : availableEvents.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
-              <p>No event albums found. Download event photos to get started.</p>
+              <p>
+                {viewerOnlyMode
+                  ? 'No local event photo albums found.'
+                  : 'No event albums found. Download event photos to get started.'}
+              </p>
             </div>
           ) : (
             <div
@@ -1166,7 +1172,11 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                       onClick={() => handleEventOpen(event)}
                     >
                       <div className="aspect-video bg-muted">
-                        <EventCoverImage event={event} cdnBase={cdnBase} />
+                        <EventCoverImage
+                          event={event}
+                          cdnBase={cdnBase}
+                          allowRemoteFallback={!viewerOnlyMode}
+                        />
                       </div>
                       <div className="space-y-3 p-4">
                         <div className="min-w-0">
@@ -1201,7 +1211,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                                 : '0 photos'}
                           </span>
                         </div>
-                        {!event.isDownloaded && (
+                        {!viewerOnlyMode && !event.isDownloaded && (
                           <Button
                             size="sm"
                             variant="secondary"
@@ -1236,11 +1246,19 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
           </div>
         ) : libraryMode === 'user' && !accountId && availableAccounts.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">
-            <p>No accounts with metadata found. Download photos to get started.</p>
+            <p>
+              {viewerOnlyMode
+                ? 'No local account photo libraries found.'
+                : 'No accounts with metadata found. Download photos to get started.'}
+            </p>
           </div>
         ) : libraryMode === 'room' && !roomId && availableRooms.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">
-            <p>No rooms with metadata found. Download room photos to get started.</p>
+            <p>
+              {viewerOnlyMode
+                ? 'No local room photo libraries found.'
+                : 'No rooms with metadata found. Download room photos to get started.'}
+            </p>
           </div>
         ) : loading ? (
           <div className="text-center py-12 text-muted-foreground">
@@ -1318,6 +1336,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
               accountMap={accountMap}
               eventMap={eventMap}
               cdnBase={cdnBase}
+              allowRemoteImages={!viewerOnlyMode}
               onScrollPositionChange={onScrollPositionChange}
               scrollContainerRef={activeScrollRef}
               accountId={accountId}
@@ -1336,6 +1355,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         eventMap={eventMap}
         cdnBase={cdnBase}
         imageComments={imageComments}
+        allowRemoteImages={!viewerOnlyMode}
       />
     </div>
   );

--- a/src/renderer/hooks/usePhotoMetadata.ts
+++ b/src/renderer/hooks/usePhotoMetadata.ts
@@ -78,7 +78,8 @@ export const usePhotoMetadata = (
   accountMap?: Map<string, string>,
   eventMap?: Map<string, string>,
   cdnBase = DEFAULT_CDN_BASE,
-  usernameMap?: Map<string, string>
+  usernameMap?: Map<string, string>,
+  allowRemoteImages = true
 ) => {
   const fallbackMap = useMemo(() => new Map<string, string>(), []);
   const safeRoomMap = roomMap ?? fallbackMap;
@@ -150,13 +151,13 @@ export const usePhotoMetadata = (
         return `local://${encodedPath}`;
       }
 
-      if (photo.ImageName) {
+      if (allowRemoteImages && photo.ImageName) {
         return buildCdnImageUrl(cdnBase, photo.ImageName);
       }
 
       return '';
     },
-    [cdnBase]
+    [allowRemoteImages, cdnBase]
   );
 
   const getPhotoEvent = useCallback(

--- a/src/shared/__tests__/viewer-only-mode.test.ts
+++ b/src/shared/__tests__/viewer-only-mode.test.ts
@@ -1,0 +1,15 @@
+import { isViewerOnlyMode } from '../viewer-only-mode';
+
+describe('viewer-only mode cutoff', () => {
+  it('is inactive before June 2, 2026 local time', () => {
+    expect(isViewerOnlyMode(new Date(2026, 5, 1, 23, 59, 59, 999))).toBe(false);
+  });
+
+  it('activates at local midnight on June 2, 2026', () => {
+    expect(isViewerOnlyMode(new Date(2026, 5, 2, 0, 0, 0, 0))).toBe(true);
+  });
+
+  it('stays active after June 2, 2026', () => {
+    expect(isViewerOnlyMode(new Date(2026, 5, 3, 12, 0, 0, 0))).toBe(true);
+  });
+});

--- a/src/shared/viewer-only-mode.ts
+++ b/src/shared/viewer-only-mode.ts
@@ -1,0 +1,18 @@
+export const VIEWER_ONLY_CUTOFF_YEAR = 2026;
+export const VIEWER_ONLY_CUTOFF_MONTH_INDEX = 6;
+export const VIEWER_ONLY_CUTOFF_DAY = 2;
+
+export const VIEWER_ONLY_MODE_ERROR =
+  'Viewer-only mode is active. Downloads and network fetches are disabled.';
+
+export function getViewerOnlyCutoffDate(): Date {
+  return new Date(
+    VIEWER_ONLY_CUTOFF_YEAR,
+    VIEWER_ONLY_CUTOFF_MONTH_INDEX,
+    VIEWER_ONLY_CUTOFF_DAY
+  );
+}
+
+export function isViewerOnlyMode(now = new Date()): boolean {
+  return now.getTime() >= getViewerOnlyCutoffDate().getTime();
+}

--- a/src/shared/viewer-only-mode.ts
+++ b/src/shared/viewer-only-mode.ts
@@ -1,5 +1,5 @@
 export const VIEWER_ONLY_CUTOFF_YEAR = 2026;
-export const VIEWER_ONLY_CUTOFF_MONTH_INDEX = 6;
+export const VIEWER_ONLY_CUTOFF_MONTH_INDEX = 5;
 export const VIEWER_ONLY_CUTOFF_DAY = 2;
 
 export const VIEWER_ONLY_MODE_ERROR =


### PR DESCRIPTION
Viewer-only mode is enforced in both the main process and renderer. Network-backed IPC handlers now return the viewer-only error, startup metadata sync and auto-updates are skipped, and download controls are hidden or disabled in the UI.

- Adds a viewer-only cutoff mode that disables downloads, RecNet network fetches, external URL opens, and update checks after June 2, 2026.
- Updates the viewer UI to prefer local image paths and avoid remote CDN fallbacks in viewer-only mode.