### PR TITLE
Batch of fixes

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,22 +66,95 @@ function emptyMetadataSyncResult(): MetadataSyncResult {
 
 /** Serialize metadata image sync jobs (launch, debug force, output path change). */
 let metadataSyncMutex: Promise<void> = Promise.resolve();
+let activeMetadataSyncAbort: AbortController | null = null;
+
+function cancelActiveMetadataSync(): void {
+  if (activeMetadataSyncAbort && !activeMetadataSyncAbort.signal.aborted) {
+    activeMetadataSyncAbort.abort();
+  }
+}
 
 function enqueueMetadataSync(force: boolean): Promise<MetadataSyncResult> {
   const next = metadataSyncMutex.then(async (): Promise<MetadataSyncResult> => {
     if (!recNetService || isViewerOnlyMode()) {
       return emptyMetadataSyncResult();
     }
+    const settings = await recNetService.getSettings();
+    if (
+      !force &&
+      (!settings.backgroundMetadataSyncEnabled ||
+        !settings.outputPathConfiguredForDownload ||
+        !(settings.resolvedOutputRoot ?? '').trim())
+    ) {
+      return emptyMetadataSyncResult();
+    }
+    const abortController = new AbortController();
+    activeMetadataSyncAbort = abortController;
     const wc = mainWindow?.webContents;
-    wc?.send('metadata-sync-state', { phase: 'running' });
+    wc?.send('metadata-sync-state', {
+      phase: 'running',
+      currentStep: 'Starting metadata image sync',
+      current: 0,
+      total: 0,
+      downloadedAssets: 0,
+      skippedAssets: 0,
+      failedAssets: 0,
+      force,
+    });
     try {
-      return await recNetService.syncMetadataLibraryAssets({ force });
+      return await recNetService.syncMetadataLibraryAssets({
+        force,
+        signal: abortController.signal,
+        onProgress: progress => {
+          wc?.send('metadata-sync-state', {
+            phase: 'running',
+            ...progress,
+          });
+        },
+      });
     } finally {
+      if (activeMetadataSyncAbort === abortController) {
+        activeMetadataSyncAbort = null;
+      }
       wc?.send('metadata-sync-state', { phase: 'idle' });
     }
   });
   metadataSyncMutex = next.then(() => undefined).catch(() => undefined);
   return next;
+}
+
+async function enqueueBackgroundMetadataSync(): Promise<void> {
+  if (!recNetService || isViewerOnlyMode()) {
+    return;
+  }
+  void enqueueMetadataSync(false);
+}
+
+async function withInlineMetadataSyncIndicator<T>(
+  event: IpcMainInvokeEvent,
+  currentStep: string,
+  work: (
+    onProgress: NonNullable<
+      Parameters<typeof recNetService.syncMetadataLibraryAssets>[0]
+    >['onProgress']
+  ) => Promise<T>
+): Promise<T> {
+  const wc = event.sender;
+  let didReport = false;
+  try {
+    return await work(progress => {
+      didReport = true;
+      wc?.send('metadata-sync-state', {
+        phase: 'running',
+        currentStep,
+        ...progress,
+      });
+    });
+  } finally {
+    if (didReport) {
+      wc?.send('metadata-sync-state', { phase: 'idle' });
+    }
+  }
 }
 
 function scheduleInitialMetadataSync(): void {
@@ -91,7 +164,7 @@ function scheduleInitialMetadataSync(): void {
   const wc = mainWindow.webContents;
   const start = () => {
     setTimeout(() => {
-      void enqueueMetadataSync(false);
+      void enqueueBackgroundMetadataSync();
     }, 500);
   };
   if (wc.isLoading()) {
@@ -665,9 +738,15 @@ ipcMain.handle(
       if (outputErr) {
         return { success: false, error: outputErr };
       }
-      const result = await recNetService.downloadPhotos(
-        params.accountId,
-        params.token
+      const result = await withInlineMetadataSyncIndicator(
+        event,
+        'Waiting for user metadata image sync',
+        onProgress =>
+          recNetService.downloadPhotos(
+            params.accountId,
+            params.token,
+            onProgress
+          )
       );
       return { success: true, data: result };
     } catch (error) {
@@ -690,9 +769,15 @@ ipcMain.handle(
       if (outputErr) {
         return { success: false, error: outputErr };
       }
-      const result = await recNetService.downloadFeedPhotos(
-        params.accountId,
-        params.token
+      const result = await withInlineMetadataSyncIndicator(
+        event,
+        'Waiting for feed metadata image sync',
+        onProgress =>
+          recNetService.downloadFeedPhotos(
+            params.accountId,
+            params.token,
+            onProgress
+          )
       );
       return { success: true, data: result };
     } catch (error) {
@@ -719,6 +804,7 @@ ipcMain.handle(
         params.accountId,
         params.token
       );
+      void enqueueBackgroundMetadataSync();
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -761,7 +847,11 @@ ipcMain.handle(
       if (outputErr) {
         return { success: false, error: outputErr };
       }
-      const result = await recNetService.downloadRoomPhotoBatch(params);
+      const result = await withInlineMetadataSyncIndicator(
+        event,
+        'Waiting for room metadata image sync',
+        onProgress => recNetService.downloadRoomPhotoBatch(params, onProgress)
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -809,7 +899,11 @@ ipcMain.handle(
       if (outputErr) {
         return { success: false, error: outputErr };
       }
-      const result = await recNetService.downloadEventPhotos(params);
+      const result = await withInlineMetadataSyncIndicator(
+        event,
+        'Waiting for event metadata image sync',
+        onProgress => recNetService.downloadEventPhotos(params, onProgress)
+      );
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -866,12 +960,17 @@ ipcMain.handle(
     const prevRoot = (before.resolvedOutputRoot ?? '').trim();
     const updated = await recNetService.updateSettings(settings);
     const nextRoot = (updated.resolvedOutputRoot ?? '').trim();
+    const backgroundSyncTurnedOn =
+      settings.backgroundMetadataSyncEnabled === true &&
+      before.backgroundMetadataSyncEnabled !== true;
+    if (metadataOutputRootChanged(prevRoot, nextRoot)) {
+      cancelActiveMetadataSync();
+    }
     if (
-      updated.outputPathConfiguredForDownload &&
-      nextRoot &&
-      metadataOutputRootChanged(prevRoot, nextRoot)
+      metadataOutputRootChanged(prevRoot, nextRoot) ||
+      backgroundSyncTurnedOn
     ) {
-      void enqueueMetadataSync(false);
+      void enqueueBackgroundMetadataSync();
     }
     return updated;
   }
@@ -879,11 +978,11 @@ ipcMain.handle(
 
 function metadataOutputRootChanged(prev: string, next: string): boolean {
   const n = next.trim();
-  if (!n) {
+  const p = prev.trim();
+  if (!p && !n) {
     return false;
   }
-  const p = prev.trim();
-  if (!p) {
+  if (!p || !n) {
     return true;
   }
   return !pathsEffectivelyEqual(p, n);
@@ -1387,23 +1486,7 @@ ipcMain.handle(
     roomId: string
   ): Promise<ApiResponse<PlayerResult[]>> => {
     try {
-      const settings = await recNetService.getSettings();
-      const root = (settings.resolvedOutputRoot ?? '').trim();
-      if (!root) {
-        return { success: true, data: [] };
-      }
-      const jsonPath = path.join(
-        root,
-        'rooms',
-        roomId,
-        `${roomId}_accounts.json`
-      );
-      if (!(await fs.pathExists(jsonPath))) {
-        return { success: true, data: [] };
-      }
-      const data: PlayerResult[] = (await fs.readJson(jsonPath)).map(
-        normalizePlayerRecord
-      );
+      const data = await recNetService.loadRoomAccountsData(roomId);
       return { success: true, data };
     } catch (error) {
       return { success: false, error: (error as Error).message };
@@ -1604,28 +1687,8 @@ ipcMain.handle(
     accountId: string
   ): Promise<ApiResponse<PlayerResult[]>> => {
     try {
-      const settings = await recNetService.getSettings();
-      const root = (settings.resolvedOutputRoot ?? '').trim();
-      if (!root) {
-        return { success: true, data: [] };
-      }
-      const accountDir = path.join(root, accountId);
-      const accountsJsonPath = path.join(
-        accountDir,
-        `${accountId}_accounts.json`
-      );
-
-      if (await fs.pathExists(accountsJsonPath)) {
-        const accountsData: PlayerResult[] = (
-          await fs.readJson(accountsJsonPath)
-        ).map(normalizePlayerRecord);
-        return {
-          success: true,
-          data: accountsData,
-        };
-      } else {
-        return { success: true, data: [] };
-      }
+      const data = await recNetService.loadUserAccountsData(accountId);
+      return { success: true, data };
     } catch (error) {
       return { success: false, error: (error as Error).message };
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -96,6 +96,8 @@ function enqueueMetadataSync(force: boolean): Promise<MetadataSyncResult> {
       currentStep: 'Starting metadata image sync',
       current: 0,
       total: 0,
+      checkedAssets: 0,
+      totalAssets: 0,
       downloadedAssets: 0,
       skippedAssets: 0,
       failedAssets: 0,

--- a/src/main/models/PlayerDto.ts
+++ b/src/main/models/PlayerDto.ts
@@ -16,4 +16,6 @@ export interface PlayerResult {
   identityFlags: number;
   createdAt: string;
   isMetaPlatformBlocked: boolean;
+  localProfileImagePath?: string;
+  localBannerImagePath?: string;
 }

--- a/src/main/services/__tests__/recnet-service.download.test.ts
+++ b/src/main/services/__tests__/recnet-service.download.test.ts
@@ -169,6 +169,99 @@ describe('RecNetService - Download Functionality', () => {
       expect(mockedFs.writeFile).toHaveBeenCalledTimes(2);
     });
 
+    it('does not run post-download metadata sync when background sync is disabled', async () => {
+      await service.updateSettings({
+        outputRoot: testOutputDir,
+        backgroundMetadataSyncEnabled: false,
+      });
+      const photos: ImageDto[] = [createMockPhoto('photo-1', 'image1.jpg')];
+      const photosJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_photos.json`
+      );
+      const photosDir = path.join(testOutputDir, testAccountId, 'photos');
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(
+        async (p: string) => {
+          if (p === photosJsonPath) return true;
+          if (p === photosDir) return true;
+          if (p === path.join(photosDir, 'photo-1.jpg')) return false;
+          return false;
+        }
+      );
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(photos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: true,
+        value: new ArrayBuffer(1024),
+        status: 200,
+      } as GenericResponse<ArrayBuffer>);
+
+      const syncSpy = jest
+        .spyOn(service as any, 'syncUserLibraryMetadataAssets')
+        .mockResolvedValue(true);
+      const metadataProgress = jest.fn();
+
+      await service.downloadPhotos(
+        testAccountId,
+        undefined,
+        metadataProgress
+      );
+
+      expect(syncSpy).not.toHaveBeenCalled();
+      expect(metadataProgress).not.toHaveBeenCalled();
+    });
+
+    it('runs post-download metadata sync when background sync is enabled', async () => {
+      await service.updateSettings({
+        outputRoot: testOutputDir,
+        backgroundMetadataSyncEnabled: true,
+      });
+      const photos: ImageDto[] = [createMockPhoto('photo-1', 'image1.jpg')];
+      const photosJsonPath = path.join(
+        testOutputDir,
+        testAccountId,
+        `${testAccountId}_photos.json`
+      );
+      const photosDir = path.join(testOutputDir, testAccountId, 'photos');
+
+      (mockedFs.pathExists as jest.Mock).mockImplementation(
+        async (p: string) => {
+          if (p === photosJsonPath) return true;
+          if (p === photosDir) return true;
+          if (p === path.join(photosDir, 'photo-1.jpg')) return false;
+          return false;
+        }
+      );
+      (mockedFs.readJson as jest.Mock).mockResolvedValue(photos);
+      (mockedFs.readdir as jest.Mock).mockResolvedValue([]);
+      mockPhotosController.downloadPhoto.mockResolvedValue({
+        success: true,
+        value: new ArrayBuffer(1024),
+        status: 200,
+      } as GenericResponse<ArrayBuffer>);
+
+      const syncSpy = jest
+        .spyOn(service as any, 'syncUserLibraryMetadataAssets')
+        .mockResolvedValue(true);
+      const metadataProgress = jest.fn();
+
+      await service.downloadPhotos(
+        testAccountId,
+        undefined,
+        metadataProgress
+      );
+
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+      expect(metadataProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentStep: 'Syncing user metadata images',
+          force: false,
+        })
+      );
+    });
+
     /**
      * Verifies that photos already present on disk are not re-downloaded.
      * This prevents wasting bandwidth and time on duplicate downloads.

--- a/src/main/services/__tests__/recnet-service.metadata-sync.test.ts
+++ b/src/main/services/__tests__/recnet-service.metadata-sync.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { RecNetService } from '../recnet-service';
+import { Semaphore } from '../../utils/semaphore';
 
 jest.mock('fs-extra', () => {
   const actualFs = jest.requireActual('fs-extra');
@@ -26,6 +27,7 @@ const mockedFs = fs as jest.Mocked<typeof fs>;
 
 describe('RecNetService - metadata library sync', () => {
   let service: RecNetService;
+  let delaySpy: jest.SpyInstance;
   const outputRoot = path.join(__dirname, 'test-output', 'metadata-sync');
 
   beforeEach(async () => {
@@ -36,7 +38,9 @@ describe('RecNetService - metadata library sync', () => {
       maxConcurrentDownloads: 1,
       interPageDelayMs: 0,
     });
-    jest.spyOn<any, any>(service as any, 'delay').mockResolvedValue(undefined);
+    delaySpy = jest
+      .spyOn<any, any>(service as any, 'delay')
+      .mockResolvedValue(undefined);
   });
 
   it('returns zero counts when output root is missing', async () => {
@@ -59,6 +63,9 @@ describe('RecNetService - metadata library sync', () => {
         return true;
       }
       if (s === path.join(accountDir, `${accountId}_accounts.json`)) {
+        return true;
+      }
+      if (s === path.join(accountDir, `${accountId}_photos.json`)) {
         return true;
       }
       if (s.includes(`${path.sep}metadata`)) {
@@ -91,6 +98,39 @@ describe('RecNetService - metadata library sync', () => {
             createdAt: '',
             isMetaPlatformBlocked: false,
           },
+          {
+            accountId: 'related-1',
+            username: 'related',
+            displayName: 'Related',
+            displayEmoji: '',
+            profileImage: 'related-p.jpg',
+            bannerImage: 'related-b.jpg',
+            isJunior: false,
+            platforms: 0,
+            personalPronouns: 0,
+            identityFlags: 0,
+            createdAt: '',
+            isMetaPlatformBlocked: false,
+          },
+        ];
+      }
+      if (s.endsWith(`${accountId}_photos.json`)) {
+        return [
+          {
+            Id: 'image-1',
+            Type: 1,
+            Accessibility: 0,
+            AccessibilityLocked: false,
+            ImageName: 'image.jpg',
+            Description: '',
+            PlayerId: accountId,
+            TaggedPlayerIds: ['related-1'],
+            RoomId: '',
+            PlayerEventId: '',
+            CreatedAt: '',
+            CheerCount: 0,
+            CommentCount: 0,
+          },
         ];
       }
       return [];
@@ -104,5 +144,338 @@ describe('RecNetService - metadata library sync', () => {
     const result = await service.syncMetadataLibraryAssets({ force: true });
     expect(result.accountsProcessed).toBe(1);
     expect(mockedFs.writeJson).toHaveBeenCalled();
+    expect((service as any).downloadPhotoWithRetry).toHaveBeenCalledWith(
+      'p.jpg',
+      undefined,
+      undefined,
+      undefined
+    );
+    expect((service as any).downloadPhotoWithRetry).not.toHaveBeenCalledWith(
+      'b.jpg',
+      undefined,
+      undefined,
+      undefined
+    );
+    expect((service as any).downloadPhotoWithRetry).not.toHaveBeenCalledWith(
+      'related-p.jpg',
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it('saves extensionless metadata images with a jpg extension', async () => {
+    const metadataDir = path.join(outputRoot, 'metadata');
+    const imageName = 'profile-image-without-extension';
+    jest.spyOn(service as any, 'downloadPhotoWithRetry').mockResolvedValue({
+      response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
+      attempts: 1,
+    });
+
+    const result = await (service as any).downloadMetadataAssetToDir(
+      imageName,
+      metadataDir,
+      true
+    );
+
+    const expectedPath = path.join(metadataDir, `${imageName}.jpg`);
+    expect(mockedFs.writeFile).toHaveBeenCalledWith(
+      expectedPath,
+      Buffer.from([1, 2, 3])
+    );
+    expect(result.entry).toEqual({
+      imageName,
+      relativePath: `${imageName}.jpg`,
+      absolutePath: expectedPath,
+    });
+  });
+
+  it('cancels metadata sync before scanning when the signal is aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      service.syncMetadataLibraryAssets({
+        force: false,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow('Metadata sync cancelled');
+    expect(mockedFs.readdir).not.toHaveBeenCalled();
+  });
+
+  it('does not rate-limit when the metadata profile image already exists locally', async () => {
+    await service.updateSettings({ interPageDelayMs: 100 });
+    const accountId = '12345';
+    const accountDir = path.join(outputRoot, accountId);
+    mockedFs.pathExists.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s === outputRoot) {
+        return true;
+      }
+      if (s === path.join(accountDir, `${accountId}_accounts.json`)) {
+        return true;
+      }
+      if (s === path.join(accountDir, `${accountId}_photos.json`)) {
+        return true;
+      }
+      return false;
+    });
+    mockedFs.readdir.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s === outputRoot) {
+        return [{ name: accountId, isDirectory: () => true }] as any;
+      }
+      return [];
+    });
+    mockedFs.readJson.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith(`${accountId}_accounts.json`)) {
+        return [
+          {
+            accountId,
+            username: 'u',
+            displayName: 'U',
+            displayEmoji: '',
+            profileImage: 'p.jpg',
+            bannerImage: 'b.jpg',
+            isJunior: false,
+            platforms: 0,
+            personalPronouns: 0,
+            identityFlags: 0,
+            createdAt: '',
+            isMetaPlatformBlocked: false,
+          },
+          {
+            accountId: 'related-1',
+            username: 'related',
+            displayName: 'Related',
+            displayEmoji: '',
+            profileImage: 'related-p.jpg',
+            bannerImage: 'related-b.jpg',
+            isJunior: false,
+            platforms: 0,
+            personalPronouns: 0,
+            identityFlags: 0,
+            createdAt: '',
+            isMetaPlatformBlocked: false,
+          },
+        ];
+      }
+      if (s.endsWith(`${accountId}_photos.json`)) {
+        return [
+          {
+            Id: 'image-1',
+            Type: 1,
+            Accessibility: 0,
+            AccessibilityLocked: false,
+            ImageName: 'image.jpg',
+            Description: '',
+            PlayerId: accountId,
+            TaggedPlayerIds: ['related-1'],
+            RoomId: '',
+            PlayerEventId: '',
+            CreatedAt: '',
+            CheerCount: 0,
+            CommentCount: 0,
+          },
+        ];
+      }
+      return [];
+    });
+
+    jest
+      .spyOn<any, any>(service as any, 'pathExistsWithContent')
+      .mockResolvedValue(true);
+    const downloadSpy = jest
+      .spyOn(service as any, 'downloadPhotoWithRetry')
+      .mockResolvedValue({
+        response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
+        attempts: 1,
+      });
+
+    const result = await service.syncMetadataLibraryAssets({ force: false });
+    expect(result.accountsProcessed).toBe(1);
+    expect(downloadSpy).not.toHaveBeenCalled();
+    expect(delaySpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the configured metadata download concurrency without an extra sync delay', async () => {
+    await service.updateSettings({
+      maxConcurrentDownloads: 2,
+      interPageDelayMs: 100,
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    jest
+      .spyOn<any, any>(service as any, 'downloadPhotoWithRetry')
+      .mockImplementation(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        inFlight--;
+        return {
+          response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
+          attempts: 1,
+        };
+      });
+
+    const synced = await (service as any).syncAccountMetadataAssets(
+      [
+        {
+          accountId: 'account-1',
+          username: 'one',
+          displayName: 'One',
+          displayEmoji: '',
+          profileImage: 'one.jpg',
+          bannerImage: '',
+          isJunior: false,
+          platforms: 0,
+          personalPronouns: 0,
+          identityFlags: 0,
+          createdAt: '',
+          isMetaPlatformBlocked: false,
+        },
+        {
+          accountId: 'account-2',
+          username: 'two',
+          displayName: 'Two',
+          displayEmoji: '',
+          profileImage: 'two.jpg',
+          bannerImage: '',
+          isJunior: false,
+          platforms: 0,
+          personalPronouns: 0,
+          identityFlags: 0,
+          createdAt: '',
+          isMetaPlatformBlocked: false,
+        },
+        {
+          accountId: 'account-3',
+          username: 'three',
+          displayName: 'Three',
+          displayEmoji: '',
+          profileImage: 'three.jpg',
+          bannerImage: '',
+          isJunior: false,
+          platforms: 0,
+          personalPronouns: 0,
+          identityFlags: 0,
+          createdAt: '',
+          isMetaPlatformBlocked: false,
+        },
+      ],
+      path.join(outputRoot, 'metadata'),
+      true,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      new Semaphore(2)
+    );
+
+    expect(Object.keys(synced)).toHaveLength(3);
+    expect(maxInFlight).toBe(2);
+    expect(delaySpy).not.toHaveBeenCalled();
+  });
+
+  it('downloads shared event creator profile and banner metadata', async () => {
+    const creatorId = 'creator-1';
+    const eventId = 'event-1';
+    const eventsRoot = path.join(outputRoot, 'events');
+    const creatorDir = path.join(eventsRoot, creatorId);
+    const eventDir = path.join(creatorDir, eventId);
+
+    mockedFs.pathExists.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      return (
+        s === outputRoot ||
+        s === eventsRoot ||
+        s === path.join(creatorDir, 'creator.json') ||
+        s === path.join(creatorDir, 'events.json') ||
+        s === path.join(eventDir, `${eventId}_photos.json`)
+      );
+    });
+    mockedFs.readdir.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s === outputRoot) {
+        return [{ name: 'events', isDirectory: () => true }] as any;
+      }
+      if (s === eventsRoot) {
+        return [{ name: creatorId, isDirectory: () => true }] as any;
+      }
+      if (s === creatorDir) {
+        return [{ name: eventId, isDirectory: () => true }] as any;
+      }
+      return [];
+    });
+    mockedFs.readJson.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith('creator.json')) {
+        return {
+          accountId: creatorId,
+          username: 'creator',
+          displayName: 'Creator',
+          displayEmoji: '',
+          profileImage: 'creator-p.jpg',
+          bannerImage: 'creator-b.jpg',
+          isJunior: false,
+          platforms: 0,
+          personalPronouns: 0,
+          identityFlags: 0,
+          createdAt: '',
+          isMetaPlatformBlocked: false,
+        };
+      }
+      if (s.endsWith('events.json')) {
+        return [
+          {
+            PlayerEventId: eventId,
+            CreatorPlayerId: creatorId,
+            ImageName: null,
+            RoomId: '',
+            SubRoomId: null,
+            ClubId: null,
+            Name: 'Event',
+            Description: '',
+            StartTime: '',
+            EndTime: '',
+            AttendeeCount: 0,
+            State: 0,
+            AccessibilityLevel: 0,
+            IsMultiInstance: false,
+            SupportMultiInstanceRoomChat: false,
+            BroadcastingRoomInstanceId: null,
+            DefaultBroadcastPermissions: 0,
+            CanRequestBroadcastPermissions: 0,
+            RecurrenceSchedule: null,
+          },
+        ];
+      }
+      if (s.endsWith(`${eventId}_photos.json`)) {
+        return [];
+      }
+      return [];
+    });
+
+    jest.spyOn(service as any, 'downloadPhotoWithRetry').mockResolvedValue({
+      response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
+      attempts: 1,
+    });
+
+    const result = await service.syncMetadataLibraryAssets({ force: true });
+
+    expect(result.creatorsProcessed).toBe(1);
+    expect((service as any).downloadPhotoWithRetry).toHaveBeenCalledWith(
+      'creator-p.jpg',
+      undefined,
+      undefined,
+      undefined
+    );
+    expect((service as any).downloadPhotoWithRetry).toHaveBeenCalledWith(
+      'creator-b.jpg',
+      undefined,
+      undefined,
+      undefined
+    );
   });
 });

--- a/src/main/services/__tests__/recnet-service.metadata-sync.test.ts
+++ b/src/main/services/__tests__/recnet-service.metadata-sync.test.ts
@@ -140,6 +140,11 @@ describe('RecNetService - metadata library sync', () => {
       response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
       attempts: 1,
     });
+    jest
+      .spyOn<any, any>(service as any, 'pathExistsWithContent')
+      .mockImplementation(async (p: unknown) => {
+        return String(p) === path.join(accountDir, 'photos', 'image-1.jpg');
+      });
 
     const result = await service.syncMetadataLibraryAssets({ force: true });
     expect(result.accountsProcessed).toBe(1);
@@ -162,6 +167,81 @@ describe('RecNetService - metadata library sync', () => {
       undefined,
       undefined
     );
+  });
+
+  it('skips user profile metadata sync when only photo metadata exists', async () => {
+    const accountId = '12345';
+    const accountDir = path.join(outputRoot, accountId);
+    mockedFs.pathExists.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      return (
+        s === outputRoot ||
+        s === path.join(accountDir, `${accountId}_accounts.json`) ||
+        s === path.join(accountDir, `${accountId}_photos.json`)
+      );
+    });
+    mockedFs.readdir.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s === outputRoot) {
+        return [{ name: accountId, isDirectory: () => true }] as any;
+      }
+      return [];
+    });
+    mockedFs.readJson.mockImplementation(async (p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith(`${accountId}_accounts.json`)) {
+        return [
+          {
+            accountId,
+            username: 'u',
+            displayName: 'U',
+            displayEmoji: '',
+            profileImage: 'p.jpg',
+            bannerImage: 'b.jpg',
+            isJunior: false,
+            platforms: 0,
+            personalPronouns: 0,
+            identityFlags: 0,
+            createdAt: '',
+            isMetaPlatformBlocked: false,
+          },
+        ];
+      }
+      if (s.endsWith(`${accountId}_photos.json`)) {
+        return [
+          {
+            Id: 'image-1',
+            Type: 1,
+            Accessibility: 0,
+            AccessibilityLocked: false,
+            ImageName: 'image.jpg',
+            Description: '',
+            PlayerId: accountId,
+            TaggedPlayerIds: [],
+            RoomId: '',
+            PlayerEventId: '',
+            CreatedAt: '',
+            CheerCount: 0,
+            CommentCount: 0,
+          },
+        ];
+      }
+      return [];
+    });
+    jest
+      .spyOn<any, any>(service as any, 'pathExistsWithContent')
+      .mockResolvedValue(false);
+    const downloadSpy = jest
+      .spyOn(service as any, 'downloadPhotoWithRetry')
+      .mockResolvedValue({
+        response: { success: true, value: new Uint8Array([1, 2, 3]).buffer },
+        attempts: 1,
+      });
+
+    const result = await service.syncMetadataLibraryAssets({ force: true });
+
+    expect(result.accountsProcessed).toBe(0);
+    expect(downloadSpy).not.toHaveBeenCalled();
   });
 
   it('saves extensionless metadata images with a jpg extension', async () => {

--- a/src/main/services/__tests__/recnet-service.save.test.ts
+++ b/src/main/services/__tests__/recnet-service.save.test.ts
@@ -152,6 +152,26 @@ describe('RecNetService - File Saving Functionality', () => {
       expect(settings.outputRoot).toBe('');
       expect(settings.resolvedOutputRoot).toBe('');
       expect(settings.outputPathConfiguredForDownload).toBe(false);
+      expect(settings.backgroundMetadataSyncEnabled).toBe(false);
+    });
+
+    it('persists background metadata sync only when explicitly enabled', async () => {
+      jest.clearAllMocks();
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
+
+      const localService = new RecNetService();
+      await localService.updateSettings({
+        backgroundMetadataSyncEnabled: true,
+      });
+
+      const savedSettings = mockedFs.writeJson.mock.calls.at(-1)?.[1] as Record<
+        string,
+        unknown
+      >;
+      const settings = await localService.getSettings();
+
+      expect(settings.backgroundMetadataSyncEnabled).toBe(true);
+      expect(savedSettings.backgroundMetadataSyncEnabled).toBe(true);
     });
 
     it('migrates relative outputRoot on load to empty and rewrites disk', async () => {

--- a/src/main/services/__tests__/recnet-service.save.test.ts
+++ b/src/main/services/__tests__/recnet-service.save.test.ts
@@ -144,7 +144,7 @@ describe('RecNetService - File Saving Functionality', () => {
       expect(rewrittenSettings).not.toHaveProperty('maxConcurrentDownloads');
     });
 
-    it('fresh install leaves output empty and marks download path as not configured', async () => {
+    it('fresh install leaves output empty, marks download path as not configured, and enables metadata sync', async () => {
       jest.clearAllMocks();
       (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
       const localService = new RecNetService();
@@ -152,16 +152,30 @@ describe('RecNetService - File Saving Functionality', () => {
       expect(settings.outputRoot).toBe('');
       expect(settings.resolvedOutputRoot).toBe('');
       expect(settings.outputPathConfiguredForDownload).toBe(false);
-      expect(settings.backgroundMetadataSyncEnabled).toBe(false);
+      expect(settings.backgroundMetadataSyncEnabled).toBe(true);
     });
 
-    it('persists background metadata sync only when explicitly enabled', async () => {
+    it('defaults missing background metadata sync settings to enabled', async () => {
+      jest.clearAllMocks();
+      (mockedFs.pathExists as jest.Mock).mockResolvedValue(true);
+      (mockedFs.readJson as jest.Mock).mockResolvedValue({
+        outputRoot: testOutputDir,
+        cdnBase: 'https://cdn.example.com/',
+      });
+
+      const localService = new RecNetService();
+      const settings = await localService.getSettings();
+
+      expect(settings.backgroundMetadataSyncEnabled).toBe(true);
+    });
+
+    it('persists background metadata sync when explicitly disabled', async () => {
       jest.clearAllMocks();
       (mockedFs.pathExists as jest.Mock).mockResolvedValue(false);
 
       const localService = new RecNetService();
       await localService.updateSettings({
-        backgroundMetadataSyncEnabled: true,
+        backgroundMetadataSyncEnabled: false,
       });
 
       const savedSettings = mockedFs.writeJson.mock.calls.at(-1)?.[1] as Record<
@@ -170,8 +184,8 @@ describe('RecNetService - File Saving Functionality', () => {
       >;
       const settings = await localService.getSettings();
 
-      expect(settings.backgroundMetadataSyncEnabled).toBe(true);
-      expect(savedSettings.backgroundMetadataSyncEnabled).toBe(true);
+      expect(settings.backgroundMetadataSyncEnabled).toBe(false);
+      expect(savedSettings.backgroundMetadataSyncEnabled).toBe(false);
     });
 
     it('migrates relative outputRoot on load to empty and rewrites disk', async () => {

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -238,7 +238,7 @@ const DEFAULT_SETTINGS: RecNetSettings = {
   cdnBase: DEFAULT_CDN_BASE,
   interPageDelayMs: 100,
   maxConcurrentDownloads: 3,
-  backgroundMetadataSyncEnabled: false,
+  backgroundMetadataSyncEnabled: true,
 };
 
 const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
@@ -399,7 +399,10 @@ function normalizeRecNetSettings(input: unknown): RecNetSettings {
     interPageDelayMs,
     maxPhotosToDownload,
     maxConcurrentDownloads,
-    backgroundMetadataSyncEnabled: raw.backgroundMetadataSyncEnabled === true,
+    backgroundMetadataSyncEnabled:
+      typeof raw.backgroundMetadataSyncEnabled === 'boolean'
+        ? raw.backgroundMetadataSyncEnabled
+        : DEFAULT_SETTINGS.backgroundMetadataSyncEnabled,
   };
 }
 

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -27,6 +27,7 @@ import {
   LibraryMoveProgress,
   LibraryMoveResult,
   MetadataSyncResult,
+  MetadataSyncState,
 } from '../../shared/types';
 import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import {
@@ -53,6 +54,54 @@ import {
   removePartialLibraryCopy,
   runLibraryMove,
 } from './library-move';
+
+type MetadataSyncProgress = Omit<MetadataSyncState, 'phase'>;
+type MetadataSyncProgressReporter = (
+  progress: Partial<MetadataSyncProgress>
+) => void;
+
+interface MetadataSyncAssetTracker {
+  report: MetadataSyncProgressReporter;
+  downloadedAssets: number;
+  skippedAssets: number;
+  failedAssets: number;
+}
+
+class MetadataSyncCancelledError extends Error {
+  constructor() {
+    super('Metadata sync cancelled');
+  }
+}
+
+function throwIfMetadataSyncAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new MetadataSyncCancelledError();
+  }
+}
+
+function createMetadataSyncAssetTracker(
+  report: MetadataSyncProgressReporter | undefined,
+  force: boolean
+): MetadataSyncAssetTracker | undefined {
+  if (!report) {
+    return undefined;
+  }
+
+  const tracker: MetadataSyncAssetTracker = {
+    report: progress =>
+      report({
+        ...progress,
+        downloadedAssets: progress.downloadedAssets ?? tracker.downloadedAssets,
+        skippedAssets: progress.skippedAssets ?? tracker.skippedAssets,
+        failedAssets: progress.failedAssets ?? tracker.failedAssets,
+        force,
+      }),
+    downloadedAssets: 0,
+    skippedAssets: 0,
+    failedAssets: 0,
+  };
+  return tracker;
+}
 
 /** Absolute directory used for reads/writes; empty if `outputRoot` is unset. */
 export function computeResolvedOutputRoot(outputRoot: string): string {
@@ -121,7 +170,7 @@ type FolderMetaV1 = {
   accountId: string;
   updatedAt: string;
   owner?: FolderMetaOwner;
-  /** Absolute paths under accountDir/metadata/profile.* / banner.* */
+  /** Absolute paths for owner metadata images. */
   ownerLocalProfileImagePath?: string;
   ownerLocalBannerImagePath?: string;
   cache?: Record<string, unknown>;
@@ -189,6 +238,7 @@ const DEFAULT_SETTINGS: RecNetSettings = {
   cdnBase: DEFAULT_CDN_BASE,
   interPageDelayMs: 100,
   maxConcurrentDownloads: 3,
+  backgroundMetadataSyncEnabled: false,
 };
 
 const PHOTO_DOWNLOAD_RETRY_COUNT = 3;
@@ -206,6 +256,8 @@ const EVENT_PHOTO_PAGE_SIZE = 100;
 const IMAGE_COMMENT_REQUEST_MIN_INTERVAL_MS = 250;
 const METADATA_SUBDIR = 'metadata';
 const METADATA_MANIFEST_FILE = 'metadata.json';
+const ACCOUNT_METADATA_MANIFEST_FILE = 'accounts-metadata.json';
+const ACCOUNT_METADATA_RECORDS_FILE = 'accounts.json';
 
 /** CDN image entry written next to files under metadata/ */
 type MetadataImageEntryV1 = {
@@ -217,12 +269,24 @@ type MetadataImageEntryV1 = {
   absolutePath: string;
 };
 
+type MetadataAssetSyncResult = {
+  entry?: MetadataImageEntryV1;
+  attemptedDownload: boolean;
+};
+
 type UserLibraryMetadataManifestV1 = {
   schemaVersion: 1;
   kind: 'user-library';
   updatedAt: string;
   profile?: MetadataImageEntryV1;
   banner?: MetadataImageEntryV1;
+  accounts?: Record<
+    string,
+    {
+      profile?: MetadataImageEntryV1;
+      banner?: MetadataImageEntryV1;
+    }
+  >;
 };
 
 type EventCreatorMetadataManifestV1 = {
@@ -243,6 +307,13 @@ type EventAlbumMetadataManifestV1 = {
   /** Server filenames; files live under events/<creatorId>/metadata/ */
   creatorProfileImageName?: string | null;
   creatorBannerImageName?: string | null;
+  accounts?: Record<
+    string,
+    {
+      profile?: MetadataImageEntryV1;
+      banner?: MetadataImageEntryV1;
+    }
+  >;
 };
 
 type RoomListingMetadataManifestV1 = {
@@ -251,7 +322,38 @@ type RoomListingMetadataManifestV1 = {
   roomId: string;
   updatedAt: string;
   roomImage?: MetadataImageEntryV1;
+  accounts?: Record<
+    string,
+    {
+      profile?: MetadataImageEntryV1;
+      banner?: MetadataImageEntryV1;
+    }
+  >;
 };
+
+type CentralAccountMetadataManifestV1 = {
+  schemaVersion: 1;
+  kind: 'account-metadata';
+  updatedAt: string;
+  accounts: Record<
+    string,
+    {
+      profile?: MetadataImageEntryV1;
+      banner?: MetadataImageEntryV1;
+    }
+  >;
+};
+
+type CentralAccountRecordsV1 = {
+  schemaVersion: 1;
+  kind: 'account-records';
+  updatedAt: string;
+  accounts: Record<string, PlayerResult>;
+};
+
+type AccountAssetMetadataManifest = Partial<UserLibraryMetadataManifestV1> &
+  Partial<EventAlbumMetadataManifestV1> &
+  Partial<RoomListingMetadataManifestV1>;
 
 type PersistedRecNetSettings = Omit<
   RecNetSettings,
@@ -297,6 +399,7 @@ function normalizeRecNetSettings(input: unknown): RecNetSettings {
     interPageDelayMs,
     maxPhotosToDownload,
     maxConcurrentDownloads,
+    backgroundMetadataSyncEnabled: raw.backgroundMetadataSyncEnabled === true,
   };
 }
 
@@ -322,6 +425,10 @@ function extractPersistedRecNetSettings(
       Number.isFinite(raw.maxPhotosToDownload) &&
       raw.maxPhotosToDownload > 0
         ? Math.floor(raw.maxPhotosToDownload)
+        : undefined,
+    backgroundMetadataSyncEnabled:
+      typeof raw.backgroundMetadataSyncEnabled === 'boolean'
+        ? raw.backgroundMetadataSyncEnabled
         : undefined,
   };
 }
@@ -467,6 +574,8 @@ export class RecNetService extends EventEmitter {
       outputRoot: this.settings.outputRoot,
       cdnBase: this.settings.cdnBase,
       maxPhotosToDownload: this.settings.maxPhotosToDownload,
+      backgroundMetadataSyncEnabled:
+        this.settings.backgroundMetadataSyncEnabled,
     };
   }
 
@@ -1603,7 +1712,8 @@ export class RecNetService extends EventEmitter {
 
   async downloadPhotos(
     accountId: string,
-    token?: string
+    token?: string,
+    metadataProgress?: MetadataSyncProgressReporter
   ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     const operation = this.startOperation();
@@ -1848,6 +1958,32 @@ export class RecNetService extends EventEmitter {
         recoveredAfterRetry,
       };
       this.logDownloadBatchSummary(trace, downloadStats);
+      if (this.settings.backgroundMetadataSyncEnabled) {
+        metadataProgress?.({
+          currentStep: 'Syncing user metadata images',
+          currentItemLabel: `User ${accountId}`,
+          current: 0,
+          total: 1,
+          downloadedAssets: 0,
+          skippedAssets: 0,
+          failedAssets: 0,
+          force: false,
+        });
+        await this.syncUserLibraryMetadataAssets(
+          accountDir,
+          accountId,
+          false,
+          token,
+          createMetadataSyncAssetTracker(metadataProgress, false)
+        );
+        metadataProgress?.({
+          currentStep: 'Synced user metadata images',
+          currentItemLabel: `User ${accountId}`,
+          current: 1,
+          total: 1,
+          force: false,
+        });
+      }
 
       return {
         accountId,
@@ -1870,7 +2006,8 @@ export class RecNetService extends EventEmitter {
 
   async downloadFeedPhotos(
     accountId: string,
-    token?: string
+    token?: string,
+    metadataProgress?: MetadataSyncProgressReporter
   ): Promise<DownloadResult> {
     await this.ensureSettingsLoaded();
     if (this.currentOperation?.cancelled) {
@@ -2121,6 +2258,32 @@ export class RecNetService extends EventEmitter {
         recoveredAfterRetry,
       };
       this.logDownloadBatchSummary(trace, downloadStats);
+      if (this.settings.backgroundMetadataSyncEnabled) {
+        metadataProgress?.({
+          currentStep: 'Syncing user metadata images',
+          currentItemLabel: `User ${accountId}`,
+          current: 0,
+          total: 1,
+          downloadedAssets: 0,
+          skippedAssets: 0,
+          failedAssets: 0,
+          force: false,
+        });
+        await this.syncUserLibraryMetadataAssets(
+          accountDir,
+          accountId,
+          false,
+          token,
+          createMetadataSyncAssetTracker(metadataProgress, false)
+        );
+        metadataProgress?.({
+          currentStep: 'Synced user metadata images',
+          currentItemLabel: `User ${accountId}`,
+          current: 1,
+          total: 1,
+          force: false,
+        });
+      }
 
       return {
         accountId,
@@ -2867,7 +3030,7 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  /** Single path segment; uses Rec Room's CDN filename (basename). */
+  /** Single path segment; uses Rec Room's CDN filename (basename) saved as jpg. */
   private safeMetadataFilename(imageName: string): string {
     const n = this.normalizeImageName(imageName);
     if (!n) {
@@ -2877,7 +3040,9 @@ export class RecNetService extends EventEmitter {
     if (!base || base === '.' || base === '..') {
       return '';
     }
-    return base;
+    const parsed = path.parse(base);
+    const stem = parsed.name || base;
+    return `${stem}.jpg`;
   }
 
   /**
@@ -2888,47 +3053,99 @@ export class RecNetService extends EventEmitter {
     imageName: string | null | undefined,
     destDir: string,
     force: boolean,
-    token?: string
-  ): Promise<MetadataImageEntryV1 | undefined> {
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    assetLabel?: string,
+    signal?: AbortSignal,
+    downloadSemaphore?: Semaphore
+  ): Promise<MetadataAssetSyncResult> {
+    throwIfMetadataSyncAborted(signal);
     const normalized = this.normalizeImageName(imageName);
     if (!normalized) {
-      return undefined;
+      return { attemptedDownload: false };
     }
     const fileName = this.safeMetadataFilename(normalized);
     if (!fileName) {
-      return undefined;
+      return { attemptedDownload: false };
     }
     const destPath = path.join(destDir, fileName);
     if (!force && (await this.pathExistsWithContent(destPath))) {
+      if (tracker) {
+        tracker.skippedAssets++;
+        tracker.report({
+          currentAssetLabel: `${assetLabel ?? 'Image'} already exists: ${fileName}`,
+          skippedAssets: tracker.skippedAssets,
+        });
+      }
       return {
-        imageName: normalized,
-        relativePath: fileName,
-        absolutePath: destPath,
-      };
-    }
-    try {
-      const attempt = await this.downloadPhotoWithRetry(
-        normalized,
-        token,
-        undefined
-      );
-      if (attempt.response?.success && attempt.response.value) {
-        await fs.ensureDir(destDir);
-        await fs.writeFile(destPath, Buffer.from(attempt.response.value));
-        return {
+        entry: {
           imageName: normalized,
           relativePath: fileName,
           absolutePath: destPath,
+        },
+        attemptedDownload: false,
+      };
+    }
+    try {
+      tracker?.report({
+        currentAssetLabel: `Downloading ${assetLabel ?? 'image'}: ${fileName}`,
+      });
+      throwIfMetadataSyncAborted(signal);
+      await downloadSemaphore?.acquire();
+      let attempt: PhotoDownloadAttempt;
+      try {
+        attempt = await this.downloadPhotoWithRetry(
+          normalized,
+          token,
+          undefined,
+          signal
+        );
+      } finally {
+        downloadSemaphore?.release();
+      }
+      throwIfMetadataSyncAborted(signal);
+      if (attempt.response?.success && attempt.response.value) {
+        await fs.ensureDir(destDir);
+        throwIfMetadataSyncAborted(signal);
+        await fs.writeFile(destPath, Buffer.from(attempt.response.value));
+        if (tracker) {
+          tracker.downloadedAssets++;
+          tracker.report({
+            currentAssetLabel: `Downloaded ${assetLabel ?? 'image'}: ${fileName}`,
+            downloadedAssets: tracker.downloadedAssets,
+          });
+        }
+        return {
+          entry: {
+            imageName: normalized,
+            relativePath: fileName,
+            absolutePath: destPath,
+          },
+          attemptedDownload: true,
         };
       }
+      if (tracker) {
+        tracker.failedAssets++;
+        tracker.report({
+          currentAssetLabel: `Failed ${assetLabel ?? 'image'}: ${fileName}`,
+          failedAssets: tracker.failedAssets,
+        });
+      }
     } catch (error) {
+      if (tracker) {
+        tracker.failedAssets++;
+        tracker.report({
+          currentAssetLabel: `Failed ${assetLabel ?? 'image'}: ${fileName}`,
+          failedAssets: tracker.failedAssets,
+        });
+      }
       console.log(
         `Metadata sync: failed to download ${normalized}: ${
           (error as Error).message
         }`
       );
     }
-    return undefined;
+    return { attemptedDownload: true };
   }
 
   private async writeMetadataManifest(
@@ -2939,19 +3156,484 @@ export class RecNetService extends EventEmitter {
     await fs.writeJson(manifestPath, payload, { spaces: 2 });
   }
 
-  private async syncMetadataDelay(): Promise<void> {
-    const ms = this.settings.interPageDelayMs ?? 0;
-    if (ms > 0) {
-      await this.delay(ms, undefined);
+  private async delayWithAbortSignal(
+    ms: number,
+    signal?: AbortSignal
+  ): Promise<void> {
+    throwIfMetadataSyncAborted(signal);
+    if (ms <= 0) {
+      return;
     }
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new MetadataSyncCancelledError());
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  private async runWithMetadataDownloadConcurrency<T>(
+    items: T[],
+    signal: AbortSignal | undefined,
+    worker: (item: T, index: number) => Promise<void>
+  ): Promise<void> {
+    const workerCount = Math.min(
+      Math.max(1, this.settings.maxConcurrentDownloads),
+      items.length
+    );
+    let nextIndex = 0;
+
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (true) {
+          throwIfMetadataSyncAborted(signal);
+          const index = nextIndex;
+          nextIndex++;
+          if (index >= items.length) {
+            return;
+          }
+          await worker(items[index], index);
+        }
+      })
+    );
+  }
+
+  private async syncAccountMetadataAssets(
+    accounts: PlayerResult[],
+    metadataDirPath: string,
+    force: boolean,
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    signal?: AbortSignal,
+    includeBanners = false,
+    downloadSemaphore?: Semaphore
+  ): Promise<
+    Record<
+      string,
+      {
+        profile?: MetadataImageEntryV1;
+        banner?: MetadataImageEntryV1;
+      }
+    >
+  > {
+    const accountAssets: Record<
+      string,
+      {
+        profile?: MetadataImageEntryV1;
+        banner?: MetadataImageEntryV1;
+      }
+    > = {};
+    const accountsDir = path.join(metadataDirPath, 'accounts');
+    const tasks: Array<
+      Promise<{
+        accountId: string;
+        kind: 'profile' | 'banner';
+        entry?: MetadataImageEntryV1;
+      }>
+    > = [];
+
+    for (const account of accounts) {
+      throwIfMetadataSyncAborted(signal);
+      const accountId = this.normalizeId(account.accountId);
+      if (!accountId) {
+        continue;
+      }
+
+      const accountDir = path.join(accountsDir, this.sanitizeFileStem(accountId));
+      const displayName =
+        account.displayName || account.username || `account ${accountId}`;
+      tasks.push(
+        this.downloadMetadataAssetToDir(
+          account.profileImage,
+          accountDir,
+          force,
+          token,
+          tracker,
+          `${displayName} profile`,
+          signal,
+          downloadSemaphore
+        ).then(result => ({
+          accountId,
+          kind: 'profile' as const,
+          entry: result.entry,
+        }))
+      );
+
+      if (includeBanners) {
+        tasks.push(
+          this.downloadMetadataAssetToDir(
+            account.bannerImage,
+            accountDir,
+            force,
+            token,
+            tracker,
+            `${displayName} banner`,
+            signal,
+            downloadSemaphore
+          ).then(result => ({
+            accountId,
+            kind: 'banner' as const,
+            entry: result.entry,
+          }))
+        );
+      }
+    }
+
+    const syncedAssets = await Promise.all(tasks);
+    for (const { accountId, kind, entry } of syncedAssets) {
+      if (!entry) {
+        continue;
+      }
+      accountAssets[accountId] = {
+        ...(accountAssets[accountId] ?? {}),
+        [kind]: entry,
+      };
+    }
+
+    return accountAssets;
+  }
+
+  private getRootMetadataDirectory(): string {
+    return path.join(this.getResolvedOutputRoot(), METADATA_SUBDIR);
+  }
+
+  private getCentralAccountMetadataManifestPath(): string {
+    return path.join(
+      this.getRootMetadataDirectory(),
+      ACCOUNT_METADATA_MANIFEST_FILE
+    );
+  }
+
+  private getCentralAccountRecordsPath(): string {
+    return path.join(this.getRootMetadataDirectory(), ACCOUNT_METADATA_RECORDS_FILE);
+  }
+
+  private async readCentralAccountMetadataManifest(): Promise<CentralAccountMetadataManifestV1 | null> {
+    const manifestPath = this.getCentralAccountMetadataManifestPath();
+    if (!(await fs.pathExists(manifestPath))) {
+      return null;
+    }
+
+    try {
+      const raw = (await fs.readJson(
+        manifestPath
+      )) as Partial<CentralAccountMetadataManifestV1>;
+      if (!raw || raw.schemaVersion !== 1 || raw.kind !== 'account-metadata') {
+        return null;
+      }
+      return {
+        schemaVersion: 1,
+        kind: 'account-metadata',
+        updatedAt: raw.updatedAt || new Date().toISOString(),
+        accounts: raw.accounts ?? {},
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async readCentralAccountRecords(): Promise<CentralAccountRecordsV1 | null> {
+    const recordsPath = this.getCentralAccountRecordsPath();
+    if (!(await fs.pathExists(recordsPath))) {
+      return null;
+    }
+
+    try {
+      const raw = (await fs.readJson(recordsPath)) as Partial<CentralAccountRecordsV1>;
+      if (!raw || raw.schemaVersion !== 1 || raw.kind !== 'account-records') {
+        return null;
+      }
+      return {
+        schemaVersion: 1,
+        kind: 'account-records',
+        updatedAt: raw.updatedAt || new Date().toISOString(),
+        accounts: raw.accounts ?? {},
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeCentralAccountRecords(
+    accounts: PlayerResult[]
+  ): Promise<CentralAccountRecordsV1> {
+    const existing = await this.readCentralAccountRecords();
+    const nextAccounts: Record<string, PlayerResult> = {
+      ...(existing?.accounts ?? {}),
+    };
+
+    for (const account of this.normalizeAccounts(accounts)) {
+      if (account.accountId) {
+        nextAccounts[account.accountId] = account;
+      }
+    }
+
+    const records: CentralAccountRecordsV1 = {
+      schemaVersion: 1,
+      kind: 'account-records',
+      updatedAt: new Date().toISOString(),
+      accounts: nextAccounts,
+    };
+    await this.writeMetadataManifest(this.getCentralAccountRecordsPath(), records);
+    return records;
+  }
+
+  private async syncCentralAccountMetadataAssets(
+    accounts: PlayerResult[],
+    force: boolean,
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    signal?: AbortSignal,
+    includeBanners = false,
+    downloadSemaphore?: Semaphore
+  ): Promise<CentralAccountMetadataManifestV1> {
+    throwIfMetadataSyncAborted(signal);
+    const metadataDirPath = this.getRootMetadataDirectory();
+    await fs.ensureDir(metadataDirPath);
+
+    const existing = await this.readCentralAccountMetadataManifest();
+    const nextAccounts: CentralAccountMetadataManifestV1['accounts'] = {
+      ...(existing?.accounts ?? {}),
+    };
+    const uniqueAccounts = new Map<string, PlayerResult>();
+    for (const account of this.normalizeAccounts(accounts)) {
+      if (account.accountId) {
+        uniqueAccounts.set(account.accountId, account);
+      }
+    }
+    await this.writeCentralAccountRecords(Array.from(uniqueAccounts.values()));
+
+    const synced = await this.syncAccountMetadataAssets(
+      Array.from(uniqueAccounts.values()),
+      metadataDirPath,
+      force,
+      token,
+      tracker,
+      signal,
+      includeBanners,
+      downloadSemaphore
+    );
+    for (const [accountId, assets] of Object.entries(synced)) {
+      nextAccounts[accountId] = assets;
+    }
+
+    const manifest: CentralAccountMetadataManifestV1 = {
+      schemaVersion: 1,
+      kind: 'account-metadata',
+      updatedAt: new Date().toISOString(),
+      accounts: nextAccounts,
+    };
+    await this.writeMetadataManifest(
+      this.getCentralAccountMetadataManifestPath(),
+      manifest
+    );
+    return manifest;
+  }
+
+  private async resolveCentralAccountAssetPaths(
+    account: PlayerResult,
+    manifest?: CentralAccountMetadataManifestV1 | null
+  ): Promise<{
+    localProfileImagePath?: string;
+    localBannerImagePath?: string;
+  }> {
+    const accountId = this.normalizeId(account.accountId);
+    if (!accountId) {
+      return {};
+    }
+
+    const metadataDirPath = this.getRootMetadataDirectory();
+    const centralManifest =
+      manifest === undefined
+        ? await this.readCentralAccountMetadataManifest()
+        : manifest;
+    const accountManifest = centralManifest?.accounts?.[accountId];
+    let localProfileImagePath = await this.resolveMetadataEntryPath(
+      metadataDirPath,
+      accountManifest?.profile
+    );
+    let localBannerImagePath = await this.resolveMetadataEntryPath(
+      metadataDirPath,
+      accountManifest?.banner
+    );
+
+    if (!localProfileImagePath) {
+      const fileName = this.safeMetadataFilename(account.profileImage);
+      const candidate = fileName
+        ? path.join(
+            metadataDirPath,
+            'accounts',
+            this.sanitizeFileStem(accountId),
+            fileName
+          )
+        : '';
+      if (candidate && (await this.pathExistsWithContent(candidate))) {
+        localProfileImagePath = candidate;
+      }
+    }
+
+    if (!localBannerImagePath) {
+      const fileName = this.safeMetadataFilename(account.bannerImage);
+      const candidate = fileName
+        ? path.join(
+            metadataDirPath,
+            'accounts',
+            this.sanitizeFileStem(accountId),
+            fileName
+          )
+        : '';
+      if (candidate && (await this.pathExistsWithContent(candidate))) {
+        localBannerImagePath = candidate;
+      }
+    }
+
+    return { localProfileImagePath, localBannerImagePath };
+  }
+
+  private async resolveMetadataEntryPath(
+    metadataDirPath: string,
+    entry?: MetadataImageEntryV1
+  ): Promise<string | undefined> {
+    const absolutePath = entry?.absolutePath;
+    if (absolutePath && (await this.pathExistsWithContent(absolutePath))) {
+      return absolutePath;
+    }
+
+    const relativePath = entry?.relativePath;
+    if (relativePath) {
+      const localPath = path.join(metadataDirPath, relativePath);
+      if (await this.pathExistsWithContent(localPath)) {
+        return localPath;
+      }
+    }
+
+    return undefined;
+  }
+
+  private async attachLocalAccountAssetPaths(
+    accounts: PlayerResult[],
+    libraryDir: string
+  ): Promise<PlayerResult[]> {
+    const metadataDirPath = path.join(libraryDir, METADATA_SUBDIR);
+    const manifestPath = path.join(metadataDirPath, METADATA_MANIFEST_FILE);
+    let manifest: AccountAssetMetadataManifest | null = null;
+    if (await fs.pathExists(manifestPath)) {
+      try {
+        manifest = (await fs.readJson(
+          manifestPath
+        )) as AccountAssetMetadataManifest;
+      } catch {
+        manifest = null;
+      }
+    }
+    const folderMeta = await this.readFolderMeta(libraryDir);
+
+    const decorated: PlayerResult[] = [];
+    const centralManifest = await this.readCentralAccountMetadataManifest();
+    const centralRecords = await this.readCentralAccountRecords();
+    for (const account of this.normalizeAccounts(accounts)) {
+      const accountId = this.normalizeId(account.accountId);
+      const centralAccount = centralRecords?.accounts?.[accountId];
+      const mergedAccount: PlayerResult = {
+        ...account,
+        ...(centralAccount ?? {}),
+        accountId,
+      };
+      const centralPaths = await this.resolveCentralAccountAssetPaths(
+        mergedAccount,
+        centralManifest
+      );
+      const accountManifest = manifest?.accounts?.[accountId];
+      let localProfileImagePath =
+        centralPaths.localProfileImagePath ??
+        (await this.resolveMetadataEntryPath(
+          metadataDirPath,
+          accountManifest?.profile
+        ));
+      let localBannerImagePath =
+        centralPaths.localBannerImagePath ??
+        (await this.resolveMetadataEntryPath(
+          metadataDirPath,
+          accountManifest?.banner
+        ));
+
+      if (!localProfileImagePath) {
+        const fileName = this.safeMetadataFilename(account.profileImage);
+        const candidate = fileName
+          ? path.join(
+              metadataDirPath,
+              'accounts',
+              this.sanitizeFileStem(accountId),
+              fileName
+            )
+          : '';
+        if (candidate && (await this.pathExistsWithContent(candidate))) {
+          localProfileImagePath = candidate;
+        }
+      }
+
+      if (!localBannerImagePath) {
+        const fileName = this.safeMetadataFilename(account.bannerImage);
+        const candidate = fileName
+          ? path.join(
+              metadataDirPath,
+              'accounts',
+              this.sanitizeFileStem(accountId),
+              fileName
+            )
+          : '';
+        if (candidate && (await this.pathExistsWithContent(candidate))) {
+          localBannerImagePath = candidate;
+        }
+      }
+
+      if (folderMeta?.accountId === accountId) {
+        localProfileImagePath =
+          localProfileImagePath ??
+          (folderMeta.ownerLocalProfileImagePath &&
+          (await this.pathExistsWithContent(folderMeta.ownerLocalProfileImagePath))
+            ? folderMeta.ownerLocalProfileImagePath
+            : await this.resolveMetadataEntryPath(
+                metadataDirPath,
+                manifest?.profile
+              ));
+        localBannerImagePath =
+          localBannerImagePath ??
+          (folderMeta.ownerLocalBannerImagePath &&
+          (await this.pathExistsWithContent(folderMeta.ownerLocalBannerImagePath))
+            ? folderMeta.ownerLocalBannerImagePath
+            : await this.resolveMetadataEntryPath(
+                metadataDirPath,
+                manifest?.banner
+              ));
+      }
+
+      decorated.push({
+        ...mergedAccount,
+        localProfileImagePath,
+        localBannerImagePath,
+      });
+    }
+
+    return decorated;
   }
 
   private async syncUserLibraryMetadataAssets(
     accountDir: string,
     accountId: string,
     force: boolean,
-    token?: string
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    syncAccounts = true,
+    signal?: AbortSignal,
+    downloadSemaphore?: Semaphore
   ): Promise<boolean> {
+    throwIfMetadataSyncAborted(signal);
     const accountsJsonPath = path.join(accountDir, `${accountId}_accounts.json`);
     if (!(await fs.pathExists(accountsJsonPath))) {
       return false;
@@ -2974,26 +3656,26 @@ export class RecNetService extends EventEmitter {
     await fs.ensureDir(metadataDirPath);
 
     const existing = await this.readFolderMeta(accountDir);
-    const profile = await this.downloadMetadataAssetToDir(
-      ownerRow.profileImage,
-      metadataDirPath,
-      force,
-      token
-    );
-    await this.syncMetadataDelay();
-    const banner = await this.downloadMetadataAssetToDir(
-      ownerRow.bannerImage,
-      metadataDirPath,
-      force,
-      token
-    );
+    const centralManifest = syncAccounts
+      ? await this.syncCentralAccountMetadataAssets(
+          accountsData,
+          force,
+          token,
+          tracker,
+          signal,
+          false,
+          downloadSemaphore
+        )
+      : await this.readCentralAccountMetadataManifest();
+    const ownerAssets =
+      centralManifest?.accounts[this.normalizeId(ownerRow.accountId)];
 
     const manifest: UserLibraryMetadataManifestV1 = {
       schemaVersion: 1,
       kind: 'user-library',
       updatedAt: new Date().toISOString(),
-      profile,
-      banner,
+      profile: ownerAssets?.profile,
+      banner: ownerAssets?.banner,
     };
     await this.writeMetadataManifest(
       path.join(metadataDirPath, METADATA_MANIFEST_FILE),
@@ -3002,9 +3684,9 @@ export class RecNetService extends EventEmitter {
 
     await this.writeFolderMeta(accountDir, accountId, {
       ownerLocalProfileImagePath:
-        profile?.absolutePath ?? existing?.ownerLocalProfileImagePath,
+        ownerAssets?.profile?.absolutePath ?? existing?.ownerLocalProfileImagePath,
       ownerLocalBannerImagePath:
-        banner?.absolutePath ?? existing?.ownerLocalBannerImagePath,
+        ownerAssets?.banner?.absolutePath ?? existing?.ownerLocalBannerImagePath,
     });
     return true;
   }
@@ -3062,8 +3744,13 @@ export class RecNetService extends EventEmitter {
   private async syncCreatorSharedMetadataAssets(
     creatorAccountId: string,
     force: boolean,
-    token?: string
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    syncAccounts = true,
+    signal?: AbortSignal,
+    downloadSemaphore?: Semaphore
   ): Promise<boolean> {
+    throwIfMetadataSyncAborted(signal);
     const creator = await this.loadCreatorPlayerResultForEvents(
       creatorAccountId
     );
@@ -3076,27 +3763,27 @@ export class RecNetService extends EventEmitter {
     );
     await fs.ensureDir(metadataDir);
 
-    const profile = await this.downloadMetadataAssetToDir(
-      creator.profileImage,
-      metadataDir,
-      force,
-      token
-    );
-    await this.syncMetadataDelay();
-    const banner = await this.downloadMetadataAssetToDir(
-      creator.bannerImage,
-      metadataDir,
-      force,
-      token
-    );
+    const centralManifest = syncAccounts
+      ? await this.syncCentralAccountMetadataAssets(
+          [creator],
+          force,
+          token,
+          tracker,
+          signal,
+          true,
+          downloadSemaphore
+        )
+      : await this.readCentralAccountMetadataManifest();
+    const creatorAssets =
+      centralManifest?.accounts[this.normalizeId(creator.accountId)];
 
     const manifest: EventCreatorMetadataManifestV1 = {
       schemaVersion: 1,
       kind: 'event-creator',
       creatorAccountId: this.normalizeId(creatorAccountId),
       updatedAt: new Date().toISOString(),
-      profile,
-      banner,
+      profile: creatorAssets?.profile,
+      banner: creatorAssets?.banner,
     };
     await this.writeMetadataManifest(
       path.join(metadataDir, METADATA_MANIFEST_FILE),
@@ -3109,8 +3796,13 @@ export class RecNetService extends EventEmitter {
     creatorAccountId: string,
     eventId: string,
     force: boolean,
-    token?: string
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    syncAccounts = true,
+    signal?: AbortSignal,
+    downloadSemaphore?: Semaphore
   ): Promise<boolean> {
+    throwIfMetadataSyncAborted(signal);
     const eventDir = this.getEventDirectory(creatorAccountId, eventId);
     const photosJsonPath = path.join(eventDir, `${eventId}_photos.json`);
     if (!(await fs.pathExists(photosJsonPath))) {
@@ -3122,7 +3814,7 @@ export class RecNetService extends EventEmitter {
     } catch {
       return false;
     }
-    if (!Array.isArray(photoList) || photoList.length === 0) {
+    if (!Array.isArray(photoList)) {
       return false;
     }
 
@@ -3162,13 +3854,17 @@ export class RecNetService extends EventEmitter {
       coverSource = 'event';
     }
 
-    const coverEntry = await this.downloadMetadataAssetToDir(
+    const coverResult = await this.downloadMetadataAssetToDir(
       coverImageName,
       metadataDirPath,
       force,
-      token
+      token,
+      tracker,
+      `event ${eventId} cover`,
+      signal,
+      downloadSemaphore
     );
-    await this.syncMetadataDelay();
+    const coverEntry = coverResult.entry;
 
     const creatorMetaPath = path.join(
       this.getCreatorEventsDirectory(creatorAccountId),
@@ -3186,6 +3882,24 @@ export class RecNetService extends EventEmitter {
         creatorBannerImageName = cm.banner?.imageName ?? null;
       } catch {
         // ignore
+      }
+    }
+
+    const accountsJsonPath = path.join(eventDir, `${eventId}_accounts.json`);
+    if (syncAccounts && (await fs.pathExists(accountsJsonPath))) {
+      try {
+        const rawAccounts = (await fs.readJson(accountsJsonPath)) as PlayerResult[];
+        await this.syncCentralAccountMetadataAssets(
+          Array.isArray(rawAccounts) ? this.normalizeAccounts(rawAccounts) : [],
+          force,
+          token,
+          tracker,
+          signal,
+          false,
+          downloadSemaphore
+        );
+      } catch {
+        // Account images are best-effort metadata.
       }
     }
 
@@ -3226,8 +3940,13 @@ export class RecNetService extends EventEmitter {
   private async syncRoomFolderMetadataAssets(
     roomId: string,
     force: boolean,
-    token?: string
+    token?: string,
+    tracker?: MetadataSyncAssetTracker,
+    syncAccounts = true,
+    signal?: AbortSignal,
+    downloadSemaphore?: Semaphore
   ): Promise<boolean> {
+    throwIfMetadataSyncAborted(signal);
     const roomDir = this.getRoomDirectory(roomId);
     const photosJsonPath = path.join(roomDir, `${roomId}_photos.json`);
     if (!(await fs.pathExists(photosJsonPath))) {
@@ -3271,12 +3990,34 @@ export class RecNetService extends EventEmitter {
 
     const metadataDirPath = path.join(roomDir, METADATA_SUBDIR);
     await fs.ensureDir(metadataDirPath);
-    const roomImage = await this.downloadMetadataAssetToDir(
+    const roomImageResult = await this.downloadMetadataAssetToDir(
       imageName,
       metadataDirPath,
       force,
-      token
+      token,
+      tracker,
+      `${room.Name || roomId} room image`,
+      signal,
+      downloadSemaphore
     );
+    const roomImage = roomImageResult.entry;
+    const accountsJsonPath = path.join(roomDir, `${roomId}_accounts.json`);
+    if (syncAccounts && (await fs.pathExists(accountsJsonPath))) {
+      try {
+        const rawAccounts = (await fs.readJson(accountsJsonPath)) as PlayerResult[];
+        await this.syncCentralAccountMetadataAssets(
+          Array.isArray(rawAccounts) ? this.normalizeAccounts(rawAccounts) : [],
+          force,
+          token,
+          tracker,
+          signal,
+          false,
+          downloadSemaphore
+        );
+      } catch {
+        // Account images are best-effort metadata.
+      }
+    }
     const manifest: RoomListingMetadataManifestV1 = {
       schemaVersion: 1,
       kind: 'room-listing',
@@ -3297,16 +4038,21 @@ export class RecNetService extends EventEmitter {
   }
 
   /**
-   * Walks the output library and downloads missing metadata images (profile/banner,
+   * Walks the output library and downloads missing metadata images (profile images,
    * event covers, room listing images). Safe to run in the background on app launch.
    */
   async syncMetadataLibraryAssets(params?: {
     force?: boolean;
     token?: string;
+    signal?: AbortSignal;
+    onProgress?: MetadataSyncProgressReporter;
   }): Promise<MetadataSyncResult> {
     await this.ensureSettingsLoaded();
     const force = Boolean(params?.force);
     const token = params?.token?.trim() || undefined;
+    const signal = params?.signal;
+    const report = params?.onProgress;
+    throwIfMetadataSyncAborted(signal);
     const root = this.getResolvedOutputRoot().trim();
     const result: MetadataSyncResult = {
       accountsProcessed: 0,
@@ -3316,95 +4062,314 @@ export class RecNetService extends EventEmitter {
     };
 
     if (!root || !(await fs.pathExists(root))) {
+      report?.({
+        currentStep: 'No output folder found',
+        current: 0,
+        total: 0,
+        force,
+      });
       return result;
     }
 
+    const tracker = createMetadataSyncAssetTracker(report, force) ?? {
+      report: () => undefined,
+      downloadedAssets: 0,
+      skippedAssets: 0,
+      failedAssets: 0,
+    };
+    const downloadSemaphore = new Semaphore(this.settings.maxConcurrentDownloads);
+    let current = 0;
+    let total = 0;
+    const emitStep = (
+      currentStep: string,
+      currentItemLabel?: string,
+      nextCurrent = current
+    ) => {
+      report?.({
+        currentStep,
+        currentItemLabel,
+        currentAssetLabel: undefined,
+        current: nextCurrent,
+        total,
+        downloadedAssets: tracker.downloadedAssets,
+        skippedAssets: tracker.skippedAssets,
+        failedAssets: tracker.failedAssets,
+        force,
+      });
+    };
+
     try {
+      throwIfMetadataSyncAborted(signal);
       const top = await fs.readdir(root, { withFileTypes: true });
-      for (const entry of top) {
-        if (!entry.isDirectory()) {
-          continue;
+      const accountNames = top
+        .filter(
+          entry =>
+            entry.isDirectory() &&
+            entry.name !== 'rooms' &&
+            entry.name !== 'events'
+        )
+        .map(entry => entry.name);
+      const accountRowsById = new Map<string, PlayerResult>();
+      const imageOwnerAccountIds = new Set<string>();
+      const collectAccountsFromFile = async (
+        accountJsonPath: string
+      ): Promise<void> => {
+        throwIfMetadataSyncAborted(signal);
+        if (!(await fs.pathExists(accountJsonPath))) {
+          return;
         }
-        const name = entry.name;
-        if (name === 'rooms' || name === 'events') {
-          continue;
+        try {
+          const raw = (await fs.readJson(accountJsonPath)) as
+            | PlayerResult
+            | PlayerResult[];
+          const accountRows = Array.isArray(raw) ? raw : raw ? [raw] : [];
+          const accounts =
+            accountRows.length > 0 ? this.normalizeAccounts(accountRows) : [];
+          for (const account of accounts) {
+            if (account.accountId) {
+              accountRowsById.set(account.accountId, account);
+            }
+          }
+        } catch {
+          // Ignore malformed context files during best-effort background sync.
         }
-        const accountDir = path.join(root, name);
-        const did = await this.syncUserLibraryMetadataAssets(
-          accountDir,
-          name,
-          force,
-          token
+      };
+      const collectImageOwnerIdsFromFile = async (
+        photosJsonPath: string
+      ): Promise<void> => {
+        throwIfMetadataSyncAborted(signal);
+        if (!(await fs.pathExists(photosJsonPath))) {
+          return;
+        }
+        try {
+          const raw = (await fs.readJson(photosJsonPath)) as Photo[];
+          const photos = Array.isArray(raw) ? this.normalizePhotos(raw) : [];
+          for (const photo of photos) {
+            const playerId = this.normalizeId(photo.PlayerId);
+            if (playerId) {
+              imageOwnerAccountIds.add(playerId);
+            }
+          }
+        } catch {
+          // Ignore malformed photo files during best-effort background sync.
+        }
+      };
+
+      for (const name of accountNames) {
+        throwIfMetadataSyncAborted(signal);
+        await collectAccountsFromFile(
+          path.join(root, name, `${name}_accounts.json`)
         );
-        if (did) {
-          result.accountsProcessed++;
-        }
-        await this.syncMetadataDelay();
+        await collectImageOwnerIdsFromFile(
+          path.join(root, name, `${name}_photos.json`)
+        );
+        await collectImageOwnerIdsFromFile(
+          path.join(root, name, `${name}_feed.json`)
+        );
       }
 
+      const eventCreators: string[] = [];
+      const eventFolders: Array<{ creatorId: string; eventId: string }> = [];
       const eventsRoot = this.getEventsRoot();
       if (await fs.pathExists(eventsRoot)) {
         const creators = await fs.readdir(eventsRoot, { withFileTypes: true });
         for (const c of creators) {
+          throwIfMetadataSyncAborted(signal);
           if (!c.isDirectory()) {
             continue;
           }
-          const creatorId = c.name;
-          const creatorDir = path.join(eventsRoot, creatorId);
-          const creatorSynced = await this.syncCreatorSharedMetadataAssets(
-            creatorId,
-            force,
-            token
-          );
-          if (creatorSynced) {
-            result.creatorsProcessed++;
-          }
-          await this.syncMetadataDelay();
-
+          eventCreators.push(c.name);
+          const creatorDir = path.join(eventsRoot, c.name);
+          await collectAccountsFromFile(path.join(creatorDir, 'creator.json'));
           const eventDirs = await fs.readdir(creatorDir, {
             withFileTypes: true,
           });
           for (const ed of eventDirs) {
-            if (!ed.isDirectory() || ed.name === METADATA_SUBDIR) {
-              continue;
+            throwIfMetadataSyncAborted(signal);
+            if (ed.isDirectory() && ed.name !== METADATA_SUBDIR) {
+              eventFolders.push({ creatorId: c.name, eventId: ed.name });
+              await collectAccountsFromFile(
+                path.join(creatorDir, ed.name, `${ed.name}_accounts.json`)
+              );
+              await collectImageOwnerIdsFromFile(
+                path.join(creatorDir, ed.name, `${ed.name}_photos.json`)
+              );
             }
-            const eid = ed.name;
-            const did = await this.syncEventFolderMetadataAssets(
-              creatorId,
-              eid,
-              force,
-              token
-            );
-            if (did) {
-              result.eventsProcessed++;
-            }
-            await this.syncMetadataDelay();
           }
         }
       }
 
+      const roomIds: string[] = [];
       const roomsRoot = this.getRoomsRoot();
       if (await fs.pathExists(roomsRoot)) {
         const roomEntries = await fs.readdir(roomsRoot, {
           withFileTypes: true,
         });
         for (const re of roomEntries) {
-          if (!re.isDirectory()) {
-            continue;
+          throwIfMetadataSyncAborted(signal);
+          if (re.isDirectory()) {
+            roomIds.push(re.name);
+            await collectAccountsFromFile(
+              path.join(roomsRoot, re.name, `${re.name}_accounts.json`)
+            );
+            await collectImageOwnerIdsFromFile(
+              path.join(roomsRoot, re.name, `${re.name}_photos.json`)
+            );
           }
-          const rid = re.name;
-          const did = await this.syncRoomFolderMetadataAssets(
-            rid,
+        }
+      }
+
+      total =
+        accountNames.length +
+        eventCreators.length +
+        eventFolders.length +
+        roomIds.length;
+      emitStep('Scanning metadata folders', undefined, 0);
+
+      const imageOwnerAccounts = Array.from(imageOwnerAccountIds)
+        .map(accountId => accountRowsById.get(accountId))
+        .filter((account): account is PlayerResult => Boolean(account));
+
+      if (imageOwnerAccounts.length > 0) {
+        throwIfMetadataSyncAborted(signal);
+        emitStep(
+          'Syncing image owner metadata',
+          `${imageOwnerAccounts.length} image owner(s)`,
+          0
+        );
+        await this.syncCentralAccountMetadataAssets(
+          imageOwnerAccounts,
+          force,
+          token,
+          tracker,
+          signal,
+          false,
+          downloadSemaphore
+        );
+        emitStep(
+          'Synced image owner metadata',
+          `${imageOwnerAccounts.length} image owner(s)`,
+          0
+        );
+      }
+
+      await this.runWithMetadataDownloadConcurrency(
+        accountNames,
+        signal,
+        async name => {
+          throwIfMetadataSyncAborted(signal);
+          const accountDir = path.join(root, name);
+          emitStep('Syncing user library metadata', `User ${name}`);
+          const did = await this.syncUserLibraryMetadataAssets(
+            accountDir,
+            name,
             force,
-            token
+            token,
+            tracker,
+            false,
+            signal,
+            downloadSemaphore
+          );
+          if (did) {
+            result.accountsProcessed++;
+          }
+          current++;
+          emitStep('Synced user library metadata', `User ${name}`);
+        }
+      );
+
+      await this.runWithMetadataDownloadConcurrency(
+        eventCreators,
+        signal,
+        async creatorId => {
+          throwIfMetadataSyncAborted(signal);
+          emitStep('Syncing event creator metadata', `Creator ${creatorId}`);
+          const creatorSynced = await this.syncCreatorSharedMetadataAssets(
+            creatorId,
+            force,
+            token,
+            tracker,
+            true,
+            signal,
+            downloadSemaphore
+          );
+          if (creatorSynced) {
+            result.creatorsProcessed++;
+          }
+          current++;
+          emitStep('Synced event creator metadata', `Creator ${creatorId}`);
+        }
+      );
+
+      await this.runWithMetadataDownloadConcurrency(
+        eventFolders,
+        signal,
+        async ({ creatorId, eventId }) => {
+          throwIfMetadataSyncAborted(signal);
+          emitStep('Syncing event album metadata', `Event ${eventId}`);
+          const did = await this.syncEventFolderMetadataAssets(
+            creatorId,
+            eventId,
+            force,
+            token,
+            tracker,
+            false,
+            signal,
+            downloadSemaphore
+          );
+          if (did) {
+            result.eventsProcessed++;
+          }
+          current++;
+          emitStep('Synced event album metadata', `Event ${eventId}`);
+        }
+      );
+
+      await this.runWithMetadataDownloadConcurrency(
+        roomIds,
+        signal,
+        async roomId => {
+          throwIfMetadataSyncAborted(signal);
+          emitStep('Syncing room metadata', `Room ${roomId}`);
+          const did = await this.syncRoomFolderMetadataAssets(
+            roomId,
+            force,
+            token,
+            tracker,
+            false,
+            signal,
+            downloadSemaphore
           );
           if (did) {
             result.roomsProcessed++;
           }
-          await this.syncMetadataDelay();
+          current++;
+          emitStep('Synced room metadata', `Room ${roomId}`);
         }
-      }
+      );
     } catch (error) {
+      if (error instanceof MetadataSyncCancelledError) {
+        report?.({
+          currentStep: 'Metadata sync cancelled',
+          current,
+          total,
+          downloadedAssets: tracker.downloadedAssets,
+          skippedAssets: tracker.skippedAssets,
+          failedAssets: tracker.failedAssets,
+          force,
+        });
+        throw error;
+      }
+      report?.({
+        currentStep: 'Metadata sync failed',
+        current,
+        total,
+        downloadedAssets: tracker.downloadedAssets,
+        skippedAssets: tracker.skippedAssets,
+        failedAssets: tracker.failedAssets,
+        force,
+        error: (error as Error).message,
+      });
       console.log(
         `Metadata library sync failed: ${(error as Error).message}`
       );
@@ -4582,13 +5547,15 @@ export class RecNetService extends EventEmitter {
   private async downloadPhotoWithRetry(
     imageName: string,
     token?: string,
-    operation?: CurrentOperation
+    operation?: CurrentOperation,
+    signal?: AbortSignal
   ): Promise<PhotoDownloadAttempt> {
     let attempts = 0;
     let lastResponse: PhotoDownloadAttempt['response'];
     let lastError: Error | undefined;
 
     while (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
+      throwIfMetadataSyncAborted(signal);
       if (operation?.cancelled || this.currentOperation?.cancelled) {
         throw this.createOperationCancelledError();
       }
@@ -4601,10 +5568,11 @@ export class RecNetService extends EventEmitter {
           this.settings.cdnBase,
           token,
           {
-            signal: operation?.controller.signal,
+            signal: signal ?? operation?.controller.signal,
             timeoutMs: PHOTO_DOWNLOAD_TIMEOUT_MS,
           }
         );
+        throwIfMetadataSyncAborted(signal);
         if (this.isCancelledResponse(response)) {
           throw this.createOperationCancelledError();
         }
@@ -4676,7 +5644,11 @@ export class RecNetService extends EventEmitter {
       }
 
       if (attempts < PHOTO_DOWNLOAD_MAX_ATTEMPTS) {
-        await this.delay(PHOTO_DOWNLOAD_RETRY_DELAY_MS, operation);
+        if (signal) {
+          await this.delayWithAbortSignal(PHOTO_DOWNLOAD_RETRY_DELAY_MS, signal);
+        } else {
+          await this.delay(PHOTO_DOWNLOAD_RETRY_DELAY_MS, operation);
+        }
       }
     }
 
@@ -4930,6 +5902,7 @@ export class RecNetService extends EventEmitter {
               if (owner && shouldWriteOwnerMeta) {
                 await this.writeFolderMeta(accountDir, accountId, { owner });
               }
+              await this.writeCentralAccountRecords(cachedAccounts);
             }
           } catch (error) {
             console.log(
@@ -5001,6 +5974,7 @@ export class RecNetService extends EventEmitter {
           await fs.writeJson(accountsJsonPath, mergedAccounts, {
             spaces: 2,
           });
+          await this.writeCentralAccountRecords(mergedAccounts);
 
           const owner = this.computeOwnerFromAccounts(
             mergedAccounts,
@@ -5774,7 +6748,57 @@ export class RecNetService extends EventEmitter {
     }
     try {
       const raw = (await fs.readJson(jsonPath)) as PlayerResult[];
-      return Array.isArray(raw) ? this.normalizeAccounts(raw) : [];
+      return Array.isArray(raw)
+        ? this.attachLocalAccountAssetPaths(
+            this.normalizeAccounts(raw),
+            eventDir
+          )
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async loadUserAccountsData(accountId: string): Promise<PlayerResult[]> {
+    await this.ensureSettingsLoaded();
+    const normalizedAccountId = this.normalizeId(accountId);
+    if (!normalizedAccountId) {
+      return [];
+    }
+    const accountDir = path.join(this.getResolvedOutputRoot(), normalizedAccountId);
+    const jsonPath = path.join(accountDir, `${normalizedAccountId}_accounts.json`);
+    if (!(await fs.pathExists(jsonPath))) {
+      return [];
+    }
+    try {
+      const raw = (await fs.readJson(jsonPath)) as PlayerResult[];
+      return Array.isArray(raw)
+        ? this.attachLocalAccountAssetPaths(
+            this.normalizeAccounts(raw),
+            accountDir
+          )
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async loadRoomAccountsData(roomId: string): Promise<PlayerResult[]> {
+    await this.ensureSettingsLoaded();
+    const normalizedRoomId = this.normalizeId(roomId);
+    if (!normalizedRoomId) {
+      return [];
+    }
+    const roomDir = this.getRoomDirectory(normalizedRoomId);
+    const jsonPath = path.join(roomDir, `${normalizedRoomId}_accounts.json`);
+    if (!(await fs.pathExists(jsonPath))) {
+      return [];
+    }
+    try {
+      const raw = (await fs.readJson(jsonPath)) as PlayerResult[];
+      return Array.isArray(raw)
+        ? this.attachLocalAccountAssetPaths(this.normalizeAccounts(raw), roomDir)
+        : [];
     } catch {
       return [];
     }
@@ -5849,11 +6873,14 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadEventPhotos(params: {
-    creatorAccountId: string;
-    eventIds: string[];
-    token?: string;
-  }): Promise<EventPhotoBatchResult> {
+  async downloadEventPhotos(
+    params: {
+      creatorAccountId: string;
+      eventIds: string[];
+      token?: string;
+    },
+    metadataProgress?: MetadataSyncProgressReporter
+  ): Promise<EventPhotoBatchResult> {
     await this.ensureSettingsLoaded();
     const operation = this.startOperation();
     const creatorAccountId = this.normalizeId(params.creatorAccountId);
@@ -6082,8 +7109,38 @@ export class RecNetService extends EventEmitter {
               ? true
               : downloadedPhotoCount >= normalizedEventPhotos.length,
         });
+        if (this.settings.backgroundMetadataSyncEnabled) {
+          metadataProgress?.({
+            currentStep: 'Syncing event metadata images',
+            currentItemLabel: event.Name || `Event ${eventId}`,
+            current: eventIndex,
+            total: eventIds.length,
+            downloadedAssets: 0,
+            skippedAssets: 0,
+            failedAssets: 0,
+            force: false,
+          });
+          await this.syncEventFolderMetadataAssets(
+            creatorAccountId,
+            eventId,
+            false,
+            params.token,
+            createMetadataSyncAssetTracker(metadataProgress, false)
+          );
+          metadataProgress?.({
+            currentStep: 'Synced event metadata images',
+            currentItemLabel: event.Name || `Event ${eventId}`,
+            current: eventIndex + 1,
+            total: eventIds.length,
+            force: false,
+          });
+        }
         const availableEvent = this.eventToAvailableEvent(event, meta);
-        const coverPath = await this.resolveLocalEventCoverPath(eventDir, meta);
+        const syncedMeta = await this.readEventFolderMeta(eventDir);
+        const coverPath = await this.resolveLocalEventCoverPath(
+          eventDir,
+          syncedMeta ?? meta
+        );
         if (coverPath) {
           availableEvent.localImagePath = coverPath;
         }
@@ -6136,18 +7193,21 @@ export class RecNetService extends EventEmitter {
     }
   }
 
-  async downloadRoomPhotoBatch(params: {
-    roomName: string;
-    token?: string;
-    startSkip?: number;
-    batchPages?: number;
-    pageSize?: number;
-    sort?: RoomPhotoSort;
-    forceAccountsRefresh?: boolean;
-    forceRoomsRefresh?: boolean;
-    forceEventsRefresh?: boolean;
-    forceImageCommentsRefresh?: boolean;
-  }): Promise<RoomPhotoBatchResult> {
+  async downloadRoomPhotoBatch(
+    params: {
+      roomName: string;
+      token?: string;
+      startSkip?: number;
+      batchPages?: number;
+      pageSize?: number;
+      sort?: RoomPhotoSort;
+      forceAccountsRefresh?: boolean;
+      forceRoomsRefresh?: boolean;
+      forceEventsRefresh?: boolean;
+      forceImageCommentsRefresh?: boolean;
+    },
+    metadataProgress?: MetadataSyncProgressReporter
+  ): Promise<RoomPhotoBatchResult> {
     await this.ensureSettingsLoaded();
     const operation = this.startOperation();
     const pageSize = Math.min(
@@ -6420,6 +7480,31 @@ export class RecNetService extends EventEmitter {
           },
         },
       });
+      if (this.settings.backgroundMetadataSyncEnabled) {
+        metadataProgress?.({
+          currentStep: 'Syncing room metadata images',
+          currentItemLabel: roomName,
+          current: 0,
+          total: 1,
+          downloadedAssets: 0,
+          skippedAssets: 0,
+          failedAssets: 0,
+          force: false,
+        });
+        await this.syncRoomFolderMetadataAssets(
+          roomId,
+          false,
+          params.token,
+          createMetadataSyncAssetTracker(metadataProgress, false)
+        );
+        metadataProgress?.({
+          currentStep: 'Synced room metadata images',
+          currentItemLabel: roomName,
+          current: 1,
+          total: 1,
+          force: false,
+        });
+      }
       this.logDownloadBatchSummary(trace, downloadStats);
       this.setOperationComplete();
 

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -4135,16 +4135,30 @@ export class RecNetService extends EventEmitter {
         }
       };
       const collectImageOwnerIdsFromFile = async (
-        photosJsonPath: string
-      ): Promise<void> => {
+        photosJsonPath: string,
+        photosDirPath: string
+      ): Promise<boolean> => {
         throwIfMetadataSyncAborted(signal);
         if (!(await fs.pathExists(photosJsonPath))) {
-          return;
+          return false;
         }
+        let hasDownloadedPhotos = false;
         try {
           const raw = (await fs.readJson(photosJsonPath)) as Photo[];
           const photos = Array.isArray(raw) ? this.normalizePhotos(raw) : [];
           for (const photo of photos) {
+            const photoId = this.normalizeId(photo.Id);
+            if (!photoId) {
+              continue;
+            }
+            const localPhotoPath = path.join(
+              photosDirPath,
+              `${this.sanitizeFileStem(photoId)}.jpg`
+            );
+            if (!(await this.pathExistsWithContent(localPhotoPath))) {
+              continue;
+            }
+            hasDownloadedPhotos = true;
             const playerId = this.normalizeId(photo.PlayerId);
             if (playerId) {
               imageOwnerAccountIds.add(playerId);
@@ -4153,19 +4167,27 @@ export class RecNetService extends EventEmitter {
         } catch {
           // Ignore malformed photo files during best-effort background sync.
         }
+        return hasDownloadedPhotos;
       };
 
+      const accountNamesWithDownloadedPhotos: string[] = [];
       for (const name of accountNames) {
         throwIfMetadataSyncAborted(signal);
+        const accountDir = path.join(root, name);
         await collectAccountsFromFile(
-          path.join(root, name, `${name}_accounts.json`)
+          path.join(accountDir, `${name}_accounts.json`)
         );
-        await collectImageOwnerIdsFromFile(
-          path.join(root, name, `${name}_photos.json`)
+        const hasUserPhotos = await collectImageOwnerIdsFromFile(
+          path.join(accountDir, `${name}_photos.json`),
+          path.join(accountDir, 'photos')
         );
-        await collectImageOwnerIdsFromFile(
-          path.join(root, name, `${name}_feed.json`)
+        const hasFeedPhotos = await collectImageOwnerIdsFromFile(
+          path.join(accountDir, `${name}_feed.json`),
+          path.join(accountDir, 'feed')
         );
+        if (hasUserPhotos || hasFeedPhotos) {
+          accountNamesWithDownloadedPhotos.push(name);
+        }
       }
 
       const eventCreators: string[] = [];
@@ -4192,7 +4214,8 @@ export class RecNetService extends EventEmitter {
                 path.join(creatorDir, ed.name, `${ed.name}_accounts.json`)
               );
               await collectImageOwnerIdsFromFile(
-                path.join(creatorDir, ed.name, `${ed.name}_photos.json`)
+                path.join(creatorDir, ed.name, `${ed.name}_photos.json`),
+                path.join(creatorDir, ed.name, 'photos')
               );
             }
           }
@@ -4213,14 +4236,15 @@ export class RecNetService extends EventEmitter {
               path.join(roomsRoot, re.name, `${re.name}_accounts.json`)
             );
             await collectImageOwnerIdsFromFile(
-              path.join(roomsRoot, re.name, `${re.name}_photos.json`)
+              path.join(roomsRoot, re.name, `${re.name}_photos.json`),
+              path.join(roomsRoot, re.name, 'photos')
             );
           }
         }
       }
 
       total =
-        accountNames.length +
+        accountNamesWithDownloadedPhotos.length +
         eventCreators.length +
         eventFolders.length +
         roomIds.length;
@@ -4254,7 +4278,7 @@ export class RecNetService extends EventEmitter {
       }
 
       await this.runWithMetadataDownloadConcurrency(
-        accountNames,
+        accountNamesWithDownloadedPhotos,
         signal,
         async name => {
           throwIfMetadataSyncAborted(signal);

--- a/src/main/services/recnet-service.ts
+++ b/src/main/services/recnet-service.ts
@@ -62,6 +62,8 @@ type MetadataSyncProgressReporter = (
 
 interface MetadataSyncAssetTracker {
   report: MetadataSyncProgressReporter;
+  checkedAssets: number;
+  totalAssets: number;
   downloadedAssets: number;
   skippedAssets: number;
   failedAssets: number;
@@ -91,11 +93,15 @@ function createMetadataSyncAssetTracker(
     report: progress =>
       report({
         ...progress,
+        checkedAssets: progress.checkedAssets ?? tracker.checkedAssets,
+        totalAssets: progress.totalAssets ?? tracker.totalAssets,
         downloadedAssets: progress.downloadedAssets ?? tracker.downloadedAssets,
         skippedAssets: progress.skippedAssets ?? tracker.skippedAssets,
         failedAssets: progress.failedAssets ?? tracker.failedAssets,
         force,
       }),
+    checkedAssets: 0,
+    totalAssets: 0,
     downloadedAssets: 0,
     skippedAssets: 0,
     failedAssets: 0,
@@ -3071,12 +3077,21 @@ export class RecNetService extends EventEmitter {
     if (!fileName) {
       return { attemptedDownload: false };
     }
+    if (tracker) {
+      tracker.totalAssets++;
+      tracker.report({
+        currentAssetLabel: `Checking ${assetLabel ?? 'image'}: ${fileName}`,
+        totalAssets: tracker.totalAssets,
+      });
+    }
     const destPath = path.join(destDir, fileName);
     if (!force && (await this.pathExistsWithContent(destPath))) {
       if (tracker) {
+        tracker.checkedAssets++;
         tracker.skippedAssets++;
         tracker.report({
           currentAssetLabel: `${assetLabel ?? 'Image'} already exists: ${fileName}`,
+          checkedAssets: tracker.checkedAssets,
           skippedAssets: tracker.skippedAssets,
         });
       }
@@ -3112,9 +3127,11 @@ export class RecNetService extends EventEmitter {
         throwIfMetadataSyncAborted(signal);
         await fs.writeFile(destPath, Buffer.from(attempt.response.value));
         if (tracker) {
+          tracker.checkedAssets++;
           tracker.downloadedAssets++;
           tracker.report({
             currentAssetLabel: `Downloaded ${assetLabel ?? 'image'}: ${fileName}`,
+            checkedAssets: tracker.checkedAssets,
             downloadedAssets: tracker.downloadedAssets,
           });
         }
@@ -3128,17 +3145,21 @@ export class RecNetService extends EventEmitter {
         };
       }
       if (tracker) {
+        tracker.checkedAssets++;
         tracker.failedAssets++;
         tracker.report({
           currentAssetLabel: `Failed ${assetLabel ?? 'image'}: ${fileName}`,
+          checkedAssets: tracker.checkedAssets,
           failedAssets: tracker.failedAssets,
         });
       }
     } catch (error) {
       if (tracker) {
+        tracker.checkedAssets++;
         tracker.failedAssets++;
         tracker.report({
           currentAssetLabel: `Failed ${assetLabel ?? 'image'}: ${fileName}`,
+          checkedAssets: tracker.checkedAssets,
           failedAssets: tracker.failedAssets,
         });
       }
@@ -4076,6 +4097,8 @@ export class RecNetService extends EventEmitter {
 
     const tracker = createMetadataSyncAssetTracker(report, force) ?? {
       report: () => undefined,
+      checkedAssets: 0,
+      totalAssets: 0,
       downloadedAssets: 0,
       skippedAssets: 0,
       failedAssets: 0,
@@ -4094,6 +4117,8 @@ export class RecNetService extends EventEmitter {
         currentAssetLabel: undefined,
         current: nextCurrent,
         total,
+        checkedAssets: tracker.checkedAssets,
+        totalAssets: tracker.totalAssets,
         downloadedAssets: tracker.downloadedAssets,
         skippedAssets: tracker.skippedAssets,
         failedAssets: tracker.failedAssets,
@@ -4380,6 +4405,8 @@ export class RecNetService extends EventEmitter {
           currentStep: 'Metadata sync cancelled',
           current,
           total,
+          checkedAssets: tracker.checkedAssets,
+          totalAssets: tracker.totalAssets,
           downloadedAssets: tracker.downloadedAssets,
           skippedAssets: tracker.skippedAssets,
           failedAssets: tracker.failedAssets,
@@ -4391,6 +4418,8 @@ export class RecNetService extends EventEmitter {
         currentStep: 'Metadata sync failed',
         current,
         total,
+        checkedAssets: tracker.checkedAssets,
+        totalAssets: tracker.totalAssets,
         downloadedAssets: tracker.downloadedAssets,
         skippedAssets: tracker.skippedAssets,
         failedAssets: tracker.failedAssets,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -81,7 +81,7 @@ function App() {
     cdnBase: DEFAULT_CDN_BASE,
     interPageDelayMs: 100,
     maxConcurrentDownloads: 3,
-    backgroundMetadataSyncEnabled: false,
+    backgroundMetadataSyncEnabled: true,
   });
 
   const [progress, setProgress] = useState<Progress>({

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -81,6 +81,7 @@ function App() {
     cdnBase: DEFAULT_CDN_BASE,
     interPageDelayMs: 100,
     maxConcurrentDownloads: 3,
+    backgroundMetadataSyncEnabled: false,
   });
 
   const [progress, setProgress] = useState<Progress>({
@@ -109,6 +110,10 @@ function App() {
   const [metadataSyncPhase, setMetadataSyncPhase] = useState<
     'idle' | 'running'
   >('idle');
+  const [metadataSyncState, setMetadataSyncState] =
+    useState<MetadataSyncState>({
+      phase: 'idle',
+    });
   const [libraryMoveDialogOpen, setLibraryMoveDialogOpen] = useState(false);
   const [resultsScrollRequestId, setResultsScrollRequestId] = useState(0);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -180,6 +185,9 @@ function App() {
     }
     const handler = (_event: unknown, state: MetadataSyncState) => {
       setMetadataSyncPhase(state.phase);
+      setMetadataSyncState(previous =>
+        state.phase === 'running' ? { ...previous, ...state } : state
+      );
     };
     window.electronAPI.onMetadataSyncState(handler);
     return () => {
@@ -1402,6 +1410,7 @@ function App() {
           onOpenLibraryMove={() => setLibraryMoveDialogOpen(true)}
           viewerOnlyMode={viewerOnlyMode}
           metadataSyncPhase={metadataSyncPhase}
+          metadataSyncState={metadataSyncState}
           onForceMetadataSync={
             viewerOnlyMode ? undefined : handleForceMetadataSync
           }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1439,7 +1439,7 @@ function App() {
                 onDownload={handleDownload}
                 onDraftChange={handleDownloadDraftChange}
                 onCancel={handleCancelDownload}
-                isDownloading={isDownloading || !!pendingPreflight}
+                isDownloading={isDownloading}
                 showCancel={isDownloading}
                 settings={settings}
                 libraryMode={libraryMode}

--- a/src/renderer/components/CustomTitleBar.tsx
+++ b/src/renderer/components/CustomTitleBar.tsx
@@ -170,6 +170,14 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
   if (syncFailedAssets > 0) {
     syncAssetParts.push(`${syncFailedAssets} failed`);
   }
+  const syncCheckedAssets = metadataSyncState?.checkedAssets ?? 0;
+  const syncTotalAssets = metadataSyncState?.totalAssets ?? 0;
+  const syncAssetProgress =
+    syncTotalAssets > 0
+      ? `${syncCheckedAssets} / ${syncTotalAssets} images checked`
+      : syncCheckedAssets > 0
+        ? `${syncCheckedAssets} images checked`
+        : 'Counting images';
 
   return (
     <>
@@ -251,9 +259,10 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
                         {Math.max(0, syncTotal - syncCurrent)} folders remaining
                       </p>
                     )}
-                    <p className="text-xs text-muted-foreground">
-                      Images: {syncAssetParts.join(', ')}
-                    </p>
+                    <div className="space-y-0.5 text-xs text-muted-foreground">
+                      <p>{syncAssetProgress}</p>
+                      <p>Images: {syncAssetParts.join(', ')}</p>
+                    </div>
                   </div>
                 </TooltipContent>
               </Tooltip>

--- a/src/renderer/components/CustomTitleBar.tsx
+++ b/src/renderer/components/CustomTitleBar.tsx
@@ -30,6 +30,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from './ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
+import type { MetadataSyncState } from '../../shared/types';
 
 interface CustomTitleBarProps {
   onDownloadClick?: () => void;
@@ -66,6 +73,7 @@ interface CustomTitleBarProps {
   onOpenLibraryMove?: () => void;
   viewerOnlyMode?: boolean;
   metadataSyncPhase?: 'idle' | 'running';
+  metadataSyncState?: MetadataSyncState;
   onForceMetadataSync?: () => void | Promise<void>;
 }
 
@@ -93,6 +101,7 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
   onOpenLibraryMove,
   viewerOnlyMode = false,
   metadataSyncPhase = 'idle',
+  metadataSyncState,
   onForceMetadataSync,
 }) => {
   const [isMaximized, setIsMaximized] = useState(false);
@@ -147,6 +156,21 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
     }
   };
 
+  const syncCurrent = metadataSyncState?.current ?? 0;
+  const syncTotal = metadataSyncState?.total ?? 0;
+  const syncPercent =
+    syncTotal > 0
+      ? Math.min(100, Math.max(0, Math.round((syncCurrent / syncTotal) * 100)))
+      : null;
+  const syncAssetParts = [
+    `${metadataSyncState?.downloadedAssets ?? 0} downloaded`,
+    `${metadataSyncState?.skippedAssets ?? 0} already local`,
+  ];
+  const syncFailedAssets = metadataSyncState?.failedAssets ?? 0;
+  if (syncFailedAssets > 0) {
+    syncAssetParts.push(`${syncFailedAssets} failed`);
+  }
+
   return (
     <>
       <div
@@ -173,7 +197,10 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
         </div>
 
         {/* Center - Icon and App Name */}
-        <div className="flex items-center gap-2 absolute left-1/2 transform -translate-x-1/2 pointer-events-none">
+        <div
+          className="flex items-center gap-2 absolute left-1/2 transform -translate-x-1/2"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
           <img
             src="/icon.png"
             alt="App Icon"
@@ -185,10 +212,52 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
             }}
           />
           {metadataSyncPhase === 'running' && (
-            <Loader2
-              className="h-4 w-4 shrink-0 animate-spin text-muted-foreground"
-              aria-hidden
-            />
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Metadata sync progress"
+                  >
+                    <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="center" className="w-72">
+                  <div className="space-y-1.5">
+                    <p className="font-medium">Syncing metadata images</p>
+                    <p className="text-xs text-muted-foreground">
+                      {metadataSyncState?.currentStep ?? 'Preparing sync'}
+                    </p>
+                    {metadataSyncState?.currentItemLabel && (
+                      <p className="text-xs">
+                        {metadataSyncState.currentItemLabel}
+                      </p>
+                    )}
+                    {metadataSyncState?.currentAssetLabel && (
+                      <p className="text-xs text-muted-foreground">
+                        {metadataSyncState.currentAssetLabel}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between text-xs">
+                      <span>
+                        {syncTotal > 0
+                          ? `${syncCurrent} / ${syncTotal} folders checked`
+                          : 'Counting folders'}
+                      </span>
+                      {syncPercent !== null && <span>{syncPercent}%</span>}
+                    </div>
+                    {syncTotal > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        {Math.max(0, syncTotal - syncCurrent)} folders remaining
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Images: {syncAssetParts.join(', ')}
+                    </p>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <span className="text-sm font-semibold text-foreground">
             Photo Downloader & Viewer
@@ -281,9 +350,10 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
               <div className="rounded-md border p-3 space-y-2">
                 <p className="text-sm font-medium">Metadata images</p>
                 <p className="text-xs text-muted-foreground">
-                  Download profile, banner, event cover, and room listing images
-                  into each folder&apos;s metadata directory. Runs automatically
-                  once when the app opens; use this to refresh or retry.
+                  Download profile, event cover, and room listing images
+                  into each folder&apos;s metadata directory. Enable background
+                  metadata image sync in Settings to run this automatically.
+                  Use this to refresh or retry.
                 </p>
                 <Button
                   type="button"

--- a/src/renderer/components/DownloadPanel.tsx
+++ b/src/renderer/components/DownloadPanel.tsx
@@ -29,7 +29,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
-import { buildCdnImageUrl } from '../../shared/cdnUrl';
 import {
   AccountInfo,
   AvailableEvent,
@@ -733,11 +732,6 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
   const profileHistoryEnabled = tokenStatus === 'verified';
   const feedPhotosVisibilitySuffix =
     tokenStatus === 'verified' ? '(Public & Private)' : '(Public)';
-  const resolvedProfilePhotoUrl =
-    usernameStatus === 'found' && resolvedAccount
-      ? buildCdnImageUrl(settings.cdnBase, resolvedAccount.profileImage)
-      : '';
-
   const renderDownloadType = (params: {
     id: string;
     title: string;
@@ -1005,20 +999,12 @@ export const DownloadPanel: React.FC<DownloadPanelProps> = ({
                 <div className="flex min-h-[3.75rem] items-center">
                   {usernameStatus === 'found' && resolvedAccount && (
                     <Card className="flex w-full flex-row items-center gap-2.5 p-2.5 shadow-none">
-                      {resolvedProfilePhotoUrl ? (
-                        <img
-                          src={resolvedProfilePhotoUrl}
-                          alt=""
-                          className="size-10 shrink-0 rounded-full object-cover ring-1 ring-border"
-                        />
-                      ) : (
-                        <div
-                          className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted ring-1 ring-border"
-                          aria-hidden
-                        >
-                          <UserRound className="size-5 text-muted-foreground" />
-                        </div>
-                      )}
+                      <div
+                        className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted ring-1 ring-border"
+                        aria-hidden
+                      >
+                        <UserRound className="size-5 text-muted-foreground" />
+                      </div>
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm font-medium leading-tight">
                           {resolvedAccount.displayName}

--- a/src/renderer/components/EventCoverImage.tsx
+++ b/src/renderer/components/EventCoverImage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
 import { AvailableEvent } from '../../shared/types';
-import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 
 interface EventCoverImageProps {
   event: AvailableEvent;
@@ -13,10 +12,8 @@ interface EventCoverImageProps {
 
 export const EventCoverImage: React.FC<EventCoverImageProps> = ({
   event,
-  cdnBase = DEFAULT_CDN_BASE,
   className = 'h-full w-full object-cover',
   iconClassName = 'h-8 w-8',
-  allowRemoteFallback = true,
 }) => {
   const sources = useMemo(() => {
     const nextSources: string[] = [];
@@ -25,16 +22,8 @@ export const EventCoverImage: React.FC<EventCoverImageProps> = ({
       nextSources.push(`local://${encodeURIComponent(event.localImagePath)}`);
     }
 
-    const imageName = event.imageName?.trim();
-    if (allowRemoteFallback && imageName && imageName.toLowerCase() !== 'null') {
-      const cdnUrl = buildCdnImageUrl(cdnBase, imageName);
-      if (cdnUrl && !nextSources.includes(cdnUrl)) {
-        nextSources.push(cdnUrl);
-      }
-    }
-
     return nextSources;
-  }, [allowRemoteFallback, cdnBase, event.imageName, event.localImagePath]);
+  }, [event.localImagePath]);
 
   const [sourceIndex, setSourceIndex] = useState(0);
 

--- a/src/renderer/components/PhotoCard.tsx
+++ b/src/renderer/components/PhotoCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   MapPin,
   Users,
+  Camera,
   Calendar,
   Heart,
   Ticket,
@@ -18,6 +19,7 @@ export interface PhotoCardProps {
   onClick: (photo: Photo) => void;
   room: string;
   users: string[];
+  photographer?: string;
   imageUrl: string;
   formattedDate?: string;
   eventName?: string;
@@ -31,6 +33,7 @@ export const PhotoCard: React.FC<PhotoCardProps> = React.memo(
     onClick,
     room,
     users,
+    photographer,
     imageUrl,
     formattedDate,
     eventName,
@@ -116,6 +119,12 @@ export const PhotoCard: React.FC<PhotoCardProps> = React.memo(
               <span className="truncate">
                 {eventName || `Event ${eventId}`}
               </span>
+            </div>
+          )}
+          {photographer && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
+              <Camera className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate min-w-0">{photographer}</span>
             </div>
           )}
           {users.length > 0 && (

--- a/src/renderer/components/PhotoDetailModal.tsx
+++ b/src/renderer/components/PhotoDetailModal.tsx
@@ -13,7 +13,6 @@ import {
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
@@ -21,7 +20,7 @@ import { Button } from '../components/ui/button';
 import { Chip } from '../components/ui/chip';
 import { ImageCommentDto, Photo } from '../../shared/types';
 import { format, isValid, parseISO } from 'date-fns';
-import { DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
+import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { usePhotoMetadata } from '../hooks/usePhotoMetadata';
 import { useFavorites } from '../hooks/useFavorites';
 
@@ -32,6 +31,7 @@ interface PhotoDetailModalProps {
   roomMap?: Map<string, string>;
   accountMap?: Map<string, string>;
   usernameMap?: Map<string, string>;
+  accountProfileImageMap?: Map<string, string>;
   eventMap?: Map<string, string>;
   cdnBase?: string;
   imageComments?: ImageCommentDto[];
@@ -52,20 +52,26 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   roomMap = new Map(),
   accountMap = new Map(),
   usernameMap = new Map(),
+  accountProfileImageMap = new Map(),
   eventMap = new Map(),
   cdnBase = DEFAULT_CDN_BASE,
   imageComments = [],
   allowRemoteImages = true,
 }) => {
-  const { getPhotoRoom, getPhotoTaggedUsers, getPhotoImageUrl, getPhotoEvent } =
-    usePhotoMetadata(
-      roomMap,
-      accountMap,
-      eventMap,
-      cdnBase,
-      usernameMap,
-      allowRemoteImages
-    );
+  const {
+    getPhotoRoom,
+    getPhotoTaggedUsers,
+    getPhotoPhotographer,
+    getPhotoImageUrl,
+    getPhotoEvent,
+  } = usePhotoMetadata(
+    roomMap,
+    accountMap,
+    eventMap,
+    cdnBase,
+    usernameMap,
+    allowRemoteImages
+  );
   const { isFavorite, toggleFavorite } = useFavorites();
   const electronAPI = (window as Window & { electronAPI?: OptionalElectronAPI })
     .electronAPI;
@@ -96,6 +102,14 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   const extended = photo as Photo & { Description?: string };
   const room = getPhotoRoom(photo);
   const taggedUsers = getPhotoTaggedUsers(photo);
+  const photographer = getPhotoPhotographer(photo);
+  const photographerProfileImageName = photographer
+    ? accountProfileImageMap.get(photographer.id)?.trim() || ''
+    : '';
+  const photographerProfileImageUrl =
+    photographerProfileImageName && allowRemoteImages
+      ? buildCdnImageUrl(cdnBase, photographerProfileImageName)
+      : '';
   const description = extended.Description || '';
   const imageUrl = getPhotoImageUrl(photo);
   const createdAt = photo.CreatedAt ? new Date(photo.CreatedAt) : null;
@@ -140,20 +154,55 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <DialogTitle>Photo Details</DialogTitle>
-              <DialogDescription>
-                View full resolution and details
-              </DialogDescription>
+          <DialogTitle className="sr-only">Photo details</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          {photographer && (
+            <div className="flex items-center gap-3 rounded-lg border border-border/80 bg-muted/30 px-3 py-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-muted-foreground">
+                  {photographerProfileImageUrl ? (
+                    <img
+                      src={photographerProfileImageUrl}
+                      alt={`${photographer.displayName} profile`}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <User className="h-6 w-6" strokeWidth={1.75} />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium uppercase text-muted-foreground">
+                    Taken By
+                  </div>
+                  <div className="truncate font-semibold">
+                    {photographer.displayName}
+                  </div>
+                  {photographer.username ? (
+                    <div className="truncate text-sm text-muted-foreground">
+                      @{photographer.username}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
             </div>
-            <div className="mt-4">
+          )}
+
+          {imageUrl && (
+            <div className="relative w-full">
+              <img
+                src={imageUrl}
+                alt={`Photo ${photo.Id}`}
+                className="w-full h-auto rounded-lg"
+              />
               <Button
-                variant={favorited ? 'default' : 'outline'}
+                variant="secondary"
                 size="icon"
-                className={
-                  favorited ? 'bg-red-500 hover:bg-red-600 text-white' : ''
-                }
+                className={`absolute right-3 top-3 h-10 w-10 rounded-full shadow-lg ${
+                  favorited
+                    ? 'bg-red-500 hover:bg-red-600 text-white'
+                    : 'bg-background/85 hover:bg-background text-muted-foreground'
+                }`}
                 onClick={handleFavoriteClick}
                 aria-label={
                   favorited ? 'Remove from favorites' : 'Add to favorites'
@@ -163,17 +212,6 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
                   className={`h-5 w-5 ${favorited ? 'fill-current' : ''}`}
                 />
               </Button>
-            </div>
-          </div>
-        </DialogHeader>
-        <div className="space-y-4">
-          {imageUrl && (
-            <div className="relative w-full">
-              <img
-                src={imageUrl}
-                alt={`Photo ${photo.Id}`}
-                className="w-full h-auto rounded-lg"
-              />
             </div>
           )}
           {description && (

--- a/src/renderer/components/PhotoDetailModal.tsx
+++ b/src/renderer/components/PhotoDetailModal.tsx
@@ -20,7 +20,7 @@ import { Button } from '../components/ui/button';
 import { Chip } from '../components/ui/chip';
 import { ImageCommentDto, Photo } from '../../shared/types';
 import { format, isValid, parseISO } from 'date-fns';
-import { buildCdnImageUrl, DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
+import { DEFAULT_CDN_BASE } from '../../shared/cdnUrl';
 import { usePhotoMetadata } from '../hooks/usePhotoMetadata';
 import { useFavorites } from '../hooks/useFavorites';
 
@@ -56,7 +56,7 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   eventMap = new Map(),
   cdnBase = DEFAULT_CDN_BASE,
   imageComments = [],
-  allowRemoteImages = true,
+  allowRemoteImages = false,
 }) => {
   const {
     getPhotoRoom,
@@ -103,12 +103,12 @@ const PhotoDetailModalComponent: React.FC<PhotoDetailModalProps> = ({
   const room = getPhotoRoom(photo);
   const taggedUsers = getPhotoTaggedUsers(photo);
   const photographer = getPhotoPhotographer(photo);
-  const photographerProfileImageName = photographer
+  const photographerProfileImagePath = photographer
     ? accountProfileImageMap.get(photographer.id)?.trim() || ''
     : '';
   const photographerProfileImageUrl =
-    photographerProfileImageName && allowRemoteImages
-      ? buildCdnImageUrl(cdnBase, photographerProfileImageName)
+    photographerProfileImagePath
+      ? `local://${encodeURIComponent(photographerProfileImagePath)}`
       : '';
   const description = extended.Description || '';
   const imageUrl = getPhotoImageUrl(photo);

--- a/src/renderer/components/PhotoGrid.tsx
+++ b/src/renderer/components/PhotoGrid.tsx
@@ -50,7 +50,13 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
   allowRemoteImages = true,
 }) => {
   const deferredSearchQuery = useDeferredValue(searchQuery);
-  const { getPhotoRoom, getPhotoUsers, getPhotoImageUrl, getPhotoEvent } =
+  const {
+    getPhotoRoom,
+    getPhotoUsers,
+    getPhotoPhotographer,
+    getPhotoImageUrl,
+    getPhotoEvent,
+  } =
     usePhotoMetadata(
       roomMap,
       accountMap,
@@ -113,6 +119,8 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
       sortedPhotos.map(photo => {
         const room = getPhotoRoom(photo).toLowerCase();
         const users = getPhotoUsers(photo).join(' ').toLowerCase();
+        const photographer =
+          getPhotoPhotographer(photo)?.displayName.toLowerCase() || '';
         const description = (photo.Description || '').toLowerCase();
         const eventInfo = getPhotoEvent(photo);
         const eventLabel = (
@@ -120,10 +128,16 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
         ).toLowerCase();
         return {
           photo,
-          key: `${room} ${users} ${description} ${eventLabel}`,
+          key: `${room} ${users} ${photographer} ${description} ${eventLabel}`,
         };
       }),
-    [sortedPhotos, getPhotoRoom, getPhotoUsers, getPhotoEvent]
+    [
+      sortedPhotos,
+      getPhotoRoom,
+      getPhotoUsers,
+      getPhotoPhotographer,
+      getPhotoEvent,
+    ]
   );
 
   const filteredPhotos = useMemo(() => {
@@ -332,6 +346,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
           {virtualPhotos.map((photo, index) => {
             const room = getPhotoRoom(photo);
             const users = getPhotoUsers(photo);
+            const photographer = getPhotoPhotographer(photo)?.displayName;
             const imageUrl = getPhotoImageUrl(photo);
             const eventInfo = getPhotoEvent(photo);
             const formattedDate = photo.CreatedAt
@@ -345,6 +360,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
                 onClick={onPhotoClick}
                 room={room}
                 users={users}
+                photographer={photographer}
                 imageUrl={imageUrl}
                 formattedDate={formattedDate}
                 eventName={eventInfo.name}
@@ -448,6 +464,8 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
                   {photos.map(photo => {
                     const room = getPhotoRoom(photo);
                     const users = getPhotoUsers(photo);
+                    const photographer =
+                      getPhotoPhotographer(photo)?.displayName;
                     const imageUrl = getPhotoImageUrl(photo);
                     const eventInfo = getPhotoEvent(photo);
                     const formattedDate = photo.CreatedAt
@@ -461,6 +479,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
                         onClick={onPhotoClick}
                         room={room}
                         users={users}
+                        photographer={photographer}
                         imageUrl={imageUrl}
                         formattedDate={formattedDate}
                         eventName={eventInfo.name}

--- a/src/renderer/components/PhotoGrid.tsx
+++ b/src/renderer/components/PhotoGrid.tsx
@@ -47,7 +47,7 @@ const PhotoGridComponent: React.FC<PhotoGridProps> = ({
   onScrollPositionChange,
   className = '',
   accountId,
-  allowRemoteImages = true,
+  allowRemoteImages = false,
 }) => {
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const {

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -128,6 +128,9 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const [usernameMap, setUsernameMap] = useState<Map<string, string>>(
     new Map()
   );
+  const [accountProfileImageMap, setAccountProfileImageMap] = useState<
+    Map<string, string>
+  >(new Map());
   const [eventMap, setEventMap] = useState<Map<string, string>>(new Map());
   const [imageComments, setImageComments] = useState<ImageCommentDto[]>([]);
   const [feedPhotos, setFeedPhotos] = useState<Photo[]>([]);
@@ -369,6 +372,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       if (!selectedEvent) {
         setAccountMap(new Map());
         setUsernameMap(new Map());
+        setAccountProfileImageMap(new Map());
         return;
       }
       try {
@@ -381,27 +385,32 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
             const accounts = result.data as PlayerResult[];
             const accountMapping = new Map<string, string>();
             const usernameMapping = new Map<string, string>();
+            const profileImageMapping = new Map<string, string>();
             accounts.forEach(account => {
               const id = String(account.accountId);
               const displayName =
                 account.displayName || account.username || id;
               accountMapping.set(id, displayName);
               usernameMapping.set(id, account.username || '');
+              profileImageMapping.set(id, account.profileImage || '');
             });
             setAccountMap(accountMapping);
             setUsernameMap(usernameMapping);
+            setAccountProfileImageMap(profileImageMapping);
           }
         }
       } catch (error) {
         console.error('Failed to load account data:', error);
         setAccountMap(new Map());
         setUsernameMap(new Map());
+        setAccountProfileImageMap(new Map());
       }
       return;
     }
     if (!activeLibraryId) {
       setAccountMap(new Map());
       setUsernameMap(new Map());
+      setAccountProfileImageMap(new Map());
       return;
     }
 
@@ -415,21 +424,25 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
           const accounts = result.data as PlayerResult[];
           const accountMapping = new Map<string, string>();
           const usernameMapping = new Map<string, string>();
+          const profileImageMapping = new Map<string, string>();
           accounts.forEach(account => {
             const id = String(account.accountId);
             const displayName =
               account.displayName || account.username || id;
             accountMapping.set(id, displayName);
             usernameMapping.set(id, account.username || '');
+            profileImageMapping.set(id, account.profileImage || '');
           });
           setAccountMap(accountMapping);
           setUsernameMap(usernameMapping);
+          setAccountProfileImageMap(profileImageMapping);
         }
       }
     } catch (error) {
       console.error('Failed to load account data:', error);
       setAccountMap(new Map());
       setUsernameMap(new Map());
+      setAccountProfileImageMap(new Map());
     }
   }, [activeLibraryId, electronAPI, libraryMode, selectedEvent]);
 
@@ -1352,6 +1365,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         roomMap={roomMap}
         accountMap={accountMap}
         usernameMap={usernameMap}
+        accountProfileImageMap={accountProfileImageMap}
         eventMap={eventMap}
         cdnBase={cdnBase}
         imageComments={imageComments}

--- a/src/renderer/components/PhotoViewer.tsx
+++ b/src/renderer/components/PhotoViewer.tsx
@@ -392,7 +392,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                 account.displayName || account.username || id;
               accountMapping.set(id, displayName);
               usernameMapping.set(id, account.username || '');
-              profileImageMapping.set(id, account.profileImage || '');
+              profileImageMapping.set(id, account.localProfileImagePath || '');
             });
             setAccountMap(accountMapping);
             setUsernameMap(usernameMapping);
@@ -431,7 +431,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
               account.displayName || account.username || id;
             accountMapping.set(id, displayName);
             usernameMapping.set(id, account.username || '');
-            profileImageMapping.set(id, account.profileImage || '');
+            profileImageMapping.set(id, account.localProfileImagePath || '');
           });
           setAccountMap(accountMapping);
           setUsernameMap(usernameMapping);
@@ -1188,7 +1188,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
                         <EventCoverImage
                           event={event}
                           cdnBase={cdnBase}
-                          allowRemoteFallback={!viewerOnlyMode}
+                          allowRemoteFallback={false}
                         />
                       </div>
                       <div className="space-y-3 p-4">
@@ -1349,7 +1349,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
               accountMap={accountMap}
               eventMap={eventMap}
               cdnBase={cdnBase}
-              allowRemoteImages={!viewerOnlyMode}
+              allowRemoteImages={false}
               onScrollPositionChange={onScrollPositionChange}
               scrollContainerRef={activeScrollRef}
               accountId={accountId}
@@ -1369,7 +1369,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         eventMap={eventMap}
         cdnBase={cdnBase}
         imageComments={imageComments}
-        allowRemoteImages={!viewerOnlyMode}
+        allowRemoteImages={false}
       />
     </div>
   );

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -66,6 +66,14 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     }
   };
 
+  const handleBackgroundMetadataSyncChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    await onUpdateSettings({
+      backgroundMetadataSyncEnabled: e.target.checked,
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -90,6 +98,28 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             onLog(`Output folder set to: ${path}`, 'info')
           }
         />
+
+        <div className="space-y-2">
+          <div className="flex items-start gap-3 rounded-md border p-3">
+            <input
+              id="background-metadata-sync"
+              type="checkbox"
+              checked={settings.backgroundMetadataSyncEnabled}
+              onChange={handleBackgroundMetadataSyncChange}
+              className="mt-1 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="background-metadata-sync">
+                Background metadata image sync
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Automatically downloads missing profile, event cover, and room
+                listing images after launch, downloads, and library folder
+                changes.
+              </p>
+            </div>
+          </div>
+        </div>
 
         {/* Delay Between Pages */}
         <div className="space-y-2">

--- a/src/renderer/hooks/usePhotoMetadata.ts
+++ b/src/renderer/hooks/usePhotoMetadata.ts
@@ -144,6 +144,26 @@ export const usePhotoMetadata = (
     [safeAccountMap, safeUsernameMap]
   );
 
+  const getPhotoPhotographer = useCallback(
+    (photo: Photo): TaggedUserInfo | null => {
+      const normalizedPlayerId = normalizeId(photo.PlayerId);
+      if (!normalizedPlayerId) {
+        return null;
+      }
+
+      const displayName =
+        getMapValue(safeAccountMap, normalizedPlayerId) || normalizedPlayerId;
+      const username = getMapValue(safeUsernameMap, normalizedPlayerId) || '';
+
+      return {
+        id: normalizedPlayerId,
+        displayName,
+        username,
+      };
+    },
+    [safeAccountMap, safeUsernameMap]
+  );
+
   const getPhotoImageUrl = useCallback(
     (photo: Photo): string => {
       if (photo.localFilePath) {
@@ -182,6 +202,7 @@ export const usePhotoMetadata = (
     getPhotoRoom,
     getPhotoUsers,
     getPhotoTaggedUsers,
+    getPhotoPhotographer,
     getPhotoImageUrl,
     getPhotoEvent,
   };

--- a/src/renderer/hooks/usePhotoMetadata.ts
+++ b/src/renderer/hooks/usePhotoMetadata.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import {
-  buildCdnImageUrl,
   DEFAULT_CDN_BASE,
 } from '../../shared/cdnUrl';
 import { Photo } from '../../shared/types';
@@ -79,8 +78,10 @@ export const usePhotoMetadata = (
   eventMap?: Map<string, string>,
   cdnBase = DEFAULT_CDN_BASE,
   usernameMap?: Map<string, string>,
-  allowRemoteImages = true
+  allowRemoteImages = false
 ) => {
+  void cdnBase;
+  void allowRemoteImages;
   const fallbackMap = useMemo(() => new Map<string, string>(), []);
   const safeRoomMap = roomMap ?? fallbackMap;
   const safeAccountMap = accountMap ?? fallbackMap;
@@ -171,13 +172,9 @@ export const usePhotoMetadata = (
         return `local://${encodedPath}`;
       }
 
-      if (allowRemoteImages && photo.ImageName) {
-        return buildCdnImageUrl(cdnBase, photo.ImageName);
-      }
-
       return '';
     },
-    [allowRemoteImages, cdnBase]
+    []
   );
 
   const getPhotoEvent = useCallback(

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -97,6 +97,8 @@ export interface MetadataSyncState {
   total?: number;
   currentItemLabel?: string;
   currentAssetLabel?: string;
+  checkedAssets?: number;
+  totalAssets?: number;
   downloadedAssets?: number;
   skippedAssets?: number;
   failedAssets?: number;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -22,6 +22,8 @@ export interface RecNetSettings {
   interPageDelayMs?: number;
   maxPhotosToDownload?: number; // Limit for testing - undefined means no limit
   maxConcurrentDownloads: number;
+  /** When true, automatically sync missing metadata images in the background. */
+  backgroundMetadataSyncEnabled: boolean;
 }
 
 export interface BulkDataRefreshOptions {
@@ -80,7 +82,7 @@ export interface LibraryMoveProgress {
 /** Result of scanning the library for missing metadata images (CDN assets). */
 export interface MetadataSyncResult {
   accountsProcessed: number;
-  /** Event-creator shared profile/banner under `events/<creatorId>/metadata/`. */
+  /** Event-creator shared profile metadata under `events/<creatorId>/metadata/`. */
   creatorsProcessed: number;
   eventsProcessed: number;
   roomsProcessed: number;
@@ -90,6 +92,15 @@ export type MetadataSyncPhase = 'idle' | 'running';
 
 export interface MetadataSyncState {
   phase: MetadataSyncPhase;
+  currentStep?: string;
+  current?: number;
+  total?: number;
+  currentItemLabel?: string;
+  currentAssetLabel?: string;
+  downloadedAssets?: number;
+  skippedAssets?: number;
+  failedAssets?: number;
+  force?: boolean;
   error?: string;
 }
 


### PR DESCRIPTION
- Adds an opt-in backgroundMetadataSyncEnabled setting, exposed in Settings and persisted with defaults.
- Expands metadata sync to download/cache local profile, banner, event cover, room listing, and account metadata assets, with central account metadata/records manifests.
- Adds progress reporting for metadata sync: current step, item, asset, counts, failures, skipped/downloaded assets, and force state.
- Adds cancellation support for active metadata sync when output paths change.
- Runs inline/background metadata sync after supported download flows when enabled.
- Updates viewer UI to prefer local-only images and removes remote CDN fallbacks in photo/event/profile display paths.
- Adds local profile/banner paths to PlayerResult.
- Refactors account loading for user/room data through RecNetService, attaching local asset paths.
- Adds/updates tests for disabled/enabled background sync, persistence, cancellation, concurrency, skipped local assets, and creator metadata downloads.