### PR TITLE
tweak: add years to timespan in stats

### DIFF
--- a/src/renderer/components/StatsDialog.tsx
+++ b/src/renderer/components/StatsDialog.tsx
@@ -366,7 +366,7 @@ interface PhotoStats {
   } | null;
   firstPhotoDate: Date | null;
   latestPhotoDate: Date | null;
-  timeSpan: { days: number; hours: number; minutes: number } | null;
+  timeSpan: { years: number; days: number; hours: number; minutes: number } | null;
   photosPerYear: Array<{
     year: string;
     userPhotos: number;
@@ -615,16 +615,18 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
         ? photosWithDates[photosWithDates.length - 1].date
         : null;
 
-    let timeSpan: { days: number; hours: number; minutes: number } | null =
-      null;
+    let timeSpan: { years: number; days: number; hours: number; minutes: number; } | null =
+     null;
     if (firstPhotoDate && latestPhotoDate) {
       const diffMs = latestPhotoDate.getTime() - firstPhotoDate.getTime();
-      const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      const years = Math.floor(totalDays / 365);
+      const days = totalDays % 365;
       const hours = Math.floor(
         (diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
       );
       const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-      timeSpan = { days, hours, minutes };
+      timeSpan = { years, days, hours, minutes };
     }
 
     // Photos per year - separate user photos and feed photos
@@ -700,10 +702,12 @@ export const StatsDialog: React.FC<StatsDialogProps> = ({
   }, [photos, feedPhotos, getPhotoRoom, getPhotoUsers]);
 
   const formatTimeGap = (
-    gap: { days: number; hours: number; minutes: number } | null
+    gap: { years?: number; days: number; hours: number; minutes: number } | null
   ): string => {
     if (!gap) return 'N/A';
     const parts: string[] = [];
+    if (gap.years && gap.years > 0)
+      parts.push(`${gap.years} year${gap.years !== 1 ? 's' : ''}`);
     if (gap.days > 0) parts.push(`${gap.days} day${gap.days !== 1 ? 's' : ''}`);
     if (gap.hours > 0)
       parts.push(`${gap.hours} hour${gap.hours !== 1 ? 's' : ''}`);


### PR DESCRIPTION
Hello! Just thought it might sense to add years to `Photo Stats > Photo Timeline > Time span` as this value is likely to be over several hundred days. Honestly it might make sense to add months as well, but personally I only wanted to know how many years passed. Since it was a small change I only tested a new build with `npm run build:win`

Changes:
- Add years to  `timeSpan` interface
- Update calculation of timeSpan to calculate years
- Prepend years in `formatTimeGap`

# Before:
<img width="1346" height="1356" alt="image" src="https://github.com/user-attachments/assets/6a627d3c-0576-49e3-9513-12b5dea33af2" />

# After:
<img width="1340" height="1357" alt="image" src="https://github.com/user-attachments/assets/cea09234-787c-44ac-a272-347a54183586" />
