### PR TITLE
fix: move download cutoff to a year out

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rr-image-downloader",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "RR Image Downloader - Download Rec Room user images.",
   "main": "dist/main/main/main.js",
   "homepage": "./",

--- a/src/shared/__tests__/viewer-only-mode.test.ts
+++ b/src/shared/__tests__/viewer-only-mode.test.ts
@@ -1,15 +1,15 @@
 import { isViewerOnlyMode } from '../viewer-only-mode';
 
 describe('viewer-only mode cutoff', () => {
-  it('is inactive before June 6, 2026 local time', () => {
-    expect(isViewerOnlyMode(new Date(2026, 5, 5, 23, 59, 59, 999))).toBe(false);
+  it('is inactive before June 6, 2027 local time', () => {
+    expect(isViewerOnlyMode(new Date(2027, 5, 5, 23, 59, 59, 999))).toBe(false);
   });
 
-  it('activates at local midnight on June 6, 2026', () => {
-    expect(isViewerOnlyMode(new Date(2026, 5, 6, 0, 0, 0, 0))).toBe(true);
+  it('activates at local midnight on June 6, 2027', () => {
+    expect(isViewerOnlyMode(new Date(2027, 5, 6, 0, 0, 0, 0))).toBe(true);
   });
 
-  it('stays active after June 6, 2026', () => {
-    expect(isViewerOnlyMode(new Date(2026, 5, 7, 12, 0, 0, 0))).toBe(true);
+  it('stays active after June 6, 2027', () => {
+    expect(isViewerOnlyMode(new Date(2027, 5, 7, 12, 0, 0, 0))).toBe(true);
   });
 });

--- a/src/shared/viewer-only-mode.ts
+++ b/src/shared/viewer-only-mode.ts
@@ -1,4 +1,4 @@
-export const VIEWER_ONLY_CUTOFF_YEAR = 2026;
+export const VIEWER_ONLY_CUTOFF_YEAR = 2027;
 export const VIEWER_ONLY_CUTOFF_MONTH_INDEX = 5;
 export const VIEWER_ONLY_CUTOFF_DAY = 6;
 


### PR DESCRIPTION
Moved the offline mode only cut off to a year out.